### PR TITLE
Improve clean stream shutdown

### DIFF
--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -55,7 +55,8 @@ object DynamicConsumer {
     initialPosition: InitialPositionInStreamExtended =
       InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON),
     isEnhancedFanOut: Boolean = true,
-    leaseTableName: Option[String] = None
+    leaseTableName: Option[String] = None,
+    workerIdentifier: String = UUID.randomUUID().toString
   ): ZStream[Blocking with R, Throwable, (String, ZStream[Any, Throwable, Record[T]])] = {
     /*
      * A queue for a single Shard and interface between the KCL threadpool and the ZIO runtime
@@ -170,7 +171,7 @@ object DynamicConsumer {
             kinesisClient,
             dynamoDbClient,
             cloudWatchClient,
-            UUID.randomUUID.toString,
+            workerIdentifier,
             () => new ZioShardProcessor(queues)
           )
           leaseTableName.fold(configsBuilder)(configsBuilder.tableName)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -127,14 +127,18 @@ object DynamicConsumer {
       override def processRecords(processRecordsInput: ProcessRecordsInput): Unit =
         shardQueue.offerRecords(processRecordsInput.records(), processRecordsInput.checkpointer())
 
-      override def leaseLost(leaseLostInput: LeaseLostInput): Unit =
+      override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
+        println(s"Lease lost for shard ${shardQueue.shardId}")
         shardQueue.stop()
+      }
 
       override def shardEnded(shardEndedInput: ShardEndedInput): Unit =
         shardQueue.stop()
 
-      override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit =
+      override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
+        println(s"Shutdown requested for shard ${shardQueue.shardId}")
         shardQueue.stop()
+      }
     }
 
     class Queues(

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -70,7 +70,7 @@ object DynamicConsumer {
       shardId: String,
       runtime: zio.Runtime[R],
       q: Queue[Exit[Option[Throwable], Chunk[Record[T]]]],
-      shutdownRequestPromise: Promise[Throwable, Unit],
+      shutdownRequest: Promise[Throwable, Unit],
       streamComplete: Promise[Throwable, Unit]
     ) {
       def offerRecords(r: java.util.List[KinesisClientRecord], checkpointer: RecordProcessorCheckpointer): Unit =
@@ -112,7 +112,7 @@ object DynamicConsumer {
         runtime.unsafeRun {
           q.takeAll *>
             q.offer(Exit.fail(None)).unit <*
-            shutdownRequestPromise.succeed(()) *>
+            shutdownRequest.succeed(()) *>
               streamComplete.await
         }
     }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -244,6 +244,16 @@ object DynamicConsumer {
     subSequenceNumber: Long,
     explicitHashKey: String,
     aggregated: Boolean,
+    /**
+     * Checkpoint the sequencenumber and subsequencenumber (if applicable) of this record
+     *
+     * Exceptions you should be prepared to handle:
+     * - [[software.amazon.kinesis.exceptions.ShutdownException]] when the lease for this shard has been lost, when
+     *   another worker has stolen the lease (this can happen at any time).
+     * - [[software.amazon.kinesis.exceptions.ThrottlingException]]
+     *
+     * See also [[RecordProcessorCheckpointer]]
+     */
     checkpoint: ZIO[Blocking, Throwable, Unit]
   )
 

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -75,7 +75,7 @@ object DynamicConsumer {
       def offerRecords(r: java.util.List[KinesisClientRecord], checkpointer: RecordProcessorCheckpointer): Unit =
         // Calls to q.offer will fail with an interruption error after the queue has been shutdown
         runtime.unsafeRun(
-          q.offer(r.asScala -> checkpointer).catchSomeCause { case c if c.interrupted => ZIO.unit }.unit
+          q.offer(r.asScala -> checkpointer).unit.catchSomeCause { case c if c.interrupted => ZIO.unit }
         )
 
       def shutdownQueue: UIO[Unit] =

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -74,9 +74,11 @@ object DynamicConsumer {
     ) {
       def offerRecords(r: java.util.List[KinesisClientRecord], checkpointer: RecordProcessorCheckpointer): Unit =
         // Calls to q.offer will fail with an interruption error after the queue has been shutdown
-        runtime.unsafeRun(q.offer(r.asScala -> checkpointer).catchSomeCause { case c if c.interrupted => ZIO.unit })
+        runtime.unsafeRun(
+          q.offer(r.asScala -> checkpointer).catchSomeCause { case c if c.interrupted => ZIO.unit }.unit
+        )
 
-      def shutdownQueue: UIO[Unit]                                                                              =
+      def shutdownQueue: UIO[Unit] =
         q.shutdown
 
       /**

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -57,121 +57,28 @@ object DynamicConsumer {
     isEnhancedFanOut: Boolean = true,
     leaseTableName: Option[String] = None
   ): ZStream[Blocking with R, Throwable, (String, ZStream[Any, Throwable, Record[T]])] = {
-
-    /*
-     * A queue for a single Shard and interface between the KCL threadpool and the ZIO runtime
-     *
-     * This queue is used by a ZStream for a single Shard
-     *
-     * The Queue uses the error channel (E type parameter) to signal failure (Some[Throwable])
-     * and completion (None)
-     */
-    case class ShardQueue(
-      shardId: String,
-      runtime: zio.Runtime[R],
-      q: Queue[Exit[Option[Throwable], Chunk[Record[T]]]],
-      shutdownRequest: Promise[Throwable, Unit],
-      streamComplete: Promise[Throwable, Unit]
-    ) {
-      def offerRecords(r: java.util.List[KinesisClientRecord], checkpointer: RecordProcessorCheckpointer): Unit =
-        // TODO only offer to the queue in unsafeRun, run the rest 'within' the regular ZIO runtime
-        runtime.unsafeRun {
-          ZIO
-            .foreach(r.asScala)(r => deserializer.deserialize(r.data()).map((r, _)))
-            .map { records =>
-              Chunk.fromIterable(records.map {
-                case (r, data) =>
-                  Record(
-                    r.sequenceNumber(),
-                    r.approximateArrivalTimestamp(),
-                    data,
-                    r.partitionKey(),
-                    r.encryptionType(),
-                    r.subSequenceNumber(),
-                    r.explicitHashKey(),
-                    r.aggregated(),
-                    checkpoint = zio.blocking.blocking {
-                      Task(checkpointer.checkpoint(r.sequenceNumber(), r.subSequenceNumber()))
-                    }
-                  )
-              })
-            }
-            .fold(e => Exit.fail(Some(e)), Exit.succeed)
-            .flatMap(q.offer)
-            .unit
-        }
-
-      /**
-       * Shutdown processing for this shard
-       *
-       * Clear everything that is still in the queue, offer a completion signal for the queue,
-       * set an interrupt signal and await stream completion (in-flight messages processed)
-       *
-       */
-      def stop(): Unit =
-        runtime.unsafeRun {
-          q.takeAll *>
-            q.offer(Exit.fail(None)).unit <*
-            shutdownRequest.succeed(()) *>
-              streamComplete.await
-        }
-    }
-
-    class ZioShardProcessor(queues: Queues) extends ShardRecordProcessor {
-      var shardQueue: ShardQueue = _
-
-      override def initialize(input: InitializationInput): Unit =
-        shardQueue = queues.newShard(input.shardId())
-
-      override def processRecords(processRecordsInput: ProcessRecordsInput): Unit =
-        shardQueue.offerRecords(processRecordsInput.records(), processRecordsInput.checkpointer())
-
-      override def leaseLost(leaseLostInput: LeaseLostInput): Unit =
-        shardQueue.stop()
-
-      override def shardEnded(shardEndedInput: ShardEndedInput): Unit =
-        shardQueue.stop()
-
-      override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit =
-        shardQueue.stop()
-    }
-
-    class Queues(
-      private val runtime: zio.Runtime[R],
-      val shards: Queue[Exit[Option[Throwable], (String, ShardStream[T])]]
-    ) {
-      def newShard(shard: String): ShardQueue =
-        runtime.unsafeRun {
-          for {
-            shutdownRequested <- Promise.make[Throwable, Unit]
-            streamComplete    <- Promise.make[Throwable, Unit]
-            queue             <- Queue
-                       .unbounded[Exit[Option[Throwable], Chunk[Record[T]]]]
-                       .map(ShardQueue(shard, runtime, _, shutdownRequested, streamComplete))
-            stream             = ZStream
-                       .fromQueue(queue.q)
-                       .collectWhileSuccess
-                       .flattenChunks
-                       .interruptWhen(shutdownRequested)
-                       .ensuring(streamComplete.succeed(()))
-            _                 <- shards.offer(Exit.succeed(shard -> stream)).unit
-          } yield queue
-        }
-    }
-
-    object Queues {
-      def make: ZManaged[R, Nothing, Queues] =
-        for {
-          runtime <- ZIO.runtime[R].toManaged_
-          q       <- Queue.unbounded[Exit[Option[Throwable], (String, ShardStream[T])]].toManaged(_.shutdown)
-        } yield new Queues(runtime, q)
-    }
-
     def retrievalConfig(kinesisClient: KinesisAsyncClient) =
       if (isEnhancedFanOut)
         new FanOutConfig(kinesisClient).streamName(streamName).applicationName(applicationName)
       else
         new PollingConfig(streamName, kinesisClient)
+
+    def toRecord(r: KinesisClientRecord, checkpointer: RecordProcessorCheckpointer): ZIO[R, Throwable, Record[T]] =
+      deserializer.deserialize(r.data()).map { data =>
+        Record(
+          r.sequenceNumber(),
+          r.approximateArrivalTimestamp(),
+          data,
+          r.partitionKey(),
+          r.encryptionType(),
+          r.subSequenceNumber(),
+          r.explicitHashKey(),
+          r.aggregated(),
+          checkpoint = zio.blocking.blocking {
+            Task(checkpointer.checkpoint(r.sequenceNumber(), r.subSequenceNumber()))
+          }
+        )
+      }
 
     // Run the scheduler
     val schedulerM =
@@ -193,8 +100,9 @@ object DynamicConsumer {
           )
           leaseTableName.fold(configsBuilder)(configsBuilder.tableName)
         }
+        env           <- ZIO.environment[R].toManaged_
 
-        scheduler     <- Task(
+        scheduler <- Task(
                        new Scheduler(
                          configsBuilder.checkpointConfig(),
                          configsBuilder.coordinatorConfig(),
@@ -208,13 +116,26 @@ object DynamicConsumer {
                            .retrievalSpecificConfig(retrievalConfig(kinesisClient))
                        )
                      ).toManaged_
-        _             <- zio.blocking
+        _         <- zio.blocking
                .blocking(ZIO(scheduler.run()))
                .fork
                .flatMap(_.join)
                .onInterrupt(ZIO.fromFutureJava(scheduler.startGracefulShutdown()).unit.orDie)
                .forkManaged
-      } yield ZStream.fromQueue(queues.shards).collectWhileSuccess
+      } yield ZStream
+        .fromQueue(queues.shards)
+        .map(_.map {
+          case (shardId, shardQueue) =>
+            val stream = ZStream
+              .fromQueue(shardQueue.q)
+              .mapConcatM { case (records, checkpointer) => ZIO.foreach(records)(toRecord(_, checkpointer)) }
+              .interruptWhen(shardQueue.shutdownRequest) // Shut down the stream when KCL signals shutdown / lease lost
+              .ensuring(shardQueue.streamComplete.succeed(())) // Signal back that stream shutdown is complete
+              .provide(env)
+
+            (shardId, stream)
+        })
+        .collectWhileSuccess
 
     ZStream.unwrapManaged(schedulerM)
   }
@@ -250,6 +171,81 @@ object DynamicConsumer {
     aggregated: Boolean,
     checkpoint: ZIO[Blocking, Throwable, Unit]
   )
+
+  /*
+   * A queue for a single Shard and interface between the KCL threadpool and the ZIO runtime
+   *
+   * This queue is used by a ZStream for a single Shard
+   *
+   * The Queue uses the error channel (E type parameter) to signal failure (Some[Throwable])
+   * and completion (None)
+   */
+  private case class ShardQueue(
+    shardId: String,
+    runtime: zio.Runtime[Any],
+    q: Queue[(Iterable[KinesisClientRecord], RecordProcessorCheckpointer)],
+    shutdownRequest: Promise[Throwable, Unit],
+    streamComplete: Promise[Throwable, Unit]
+  ) {
+    def offerRecords(r: java.util.List[KinesisClientRecord], checkpointer: RecordProcessorCheckpointer): Unit =
+      runtime.unsafeRun(q.offer(r.asScala -> checkpointer).unit)
+
+    /**
+     * Shutdown processing for this shard
+     *
+     * Clear everything that is still in the queue, offer a completion signal for the queue,
+     * set an interrupt signal and await stream completion (in-flight messages processed)
+     *
+     */
+    def stop(): Unit                                                                                          =
+      runtime.unsafeRun {
+        q.takeAll.unit <* shutdownRequest.succeed(()) *> streamComplete.await
+      }
+  }
+
+  private class ZioShardProcessor(queues: Queues) extends ShardRecordProcessor {
+    var shardQueue: ShardQueue = _
+
+    override def initialize(input: InitializationInput): Unit =
+      shardQueue = queues.newShard(input.shardId())
+
+    override def processRecords(processRecordsInput: ProcessRecordsInput): Unit =
+      shardQueue.offerRecords(processRecordsInput.records(), processRecordsInput.checkpointer())
+
+    override def leaseLost(leaseLostInput: LeaseLostInput): Unit =
+      shardQueue.stop()
+
+    override def shardEnded(shardEndedInput: ShardEndedInput): Unit =
+      shardQueue.stop()
+
+    override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit =
+      shardQueue.stop()
+  }
+
+  private class Queues(
+    private val runtime: zio.Runtime[Any],
+    val shards: Queue[Exit[Option[Throwable], (String, ShardQueue)]]
+  ) {
+    def newShard(shard: String): ShardQueue =
+      runtime.unsafeRun {
+        for {
+          shutdownRequested <- Promise.make[Throwable, Unit]
+          streamComplete    <- Promise.make[Throwable, Unit]
+          queue             <- Queue
+                     .unbounded[(Iterable[KinesisClientRecord], RecordProcessorCheckpointer)]
+                     .map(ShardQueue(shard, runtime, _, shutdownRequested, streamComplete))
+          _                 <- shards.offer(Exit.succeed(shard -> queue)).unit
+        } yield queue
+      }
+  }
+
+  private object Queues {
+    def make: ZManaged[Any, Nothing, Queues] =
+      for {
+        runtime <- ZIO.runtime[Any].toManaged_
+        q       <- Queue.unbounded[Exit[Option[Throwable], (String, ShardQueue)]].toManaged(_.shutdown)
+      } yield new Queues(runtime, q)
+  }
 
   type ShardStream[T] = ZStream[Any, Throwable, Record[T]]
 }

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -44,38 +44,38 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
 
   override def spec =
     suite("DynamicConsumer")(
-      testM("consume records produced on all shards produced on the stream") {
-
-        val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
-        val applicationName = "zio-test-" + UUID.randomUUID().toString
-
-        (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 2)).use {
-          client =>
-            for {
-              _ <- putStrLn("Putting records")
-              _ <- client
-                     .putRecords(
-                       streamName,
-                       Serde.asciiString,
-                       Seq(ProducerRecord("key1", "msg1"), ProducerRecord("key2", "msg2"))
-                     )
-                     .retry(retryOnResourceNotFound)
-                     .provideLayer(Clock.live)
-
-              _ <- putStrLn("Starting dynamic consumer")
-              _ <- LocalStackDynamicConsumer
-                     .shardedStream(
-                       streamName,
-                       applicationName = applicationName,
-                       deserializer = Serde.asciiString
-                     )
-                     .flatMapPar(Int.MaxValue)(_._2)
-                     .take(2)
-                     .tap(r => putStrLn(s"Got record $r") *> r.checkpoint.retry(Schedule.exponential(100.millis)))
-                     .runCollect
-            } yield assertCompletes
-        }
-      },
+//      testM("consume records produced on all shards produced on the stream") {
+//
+//        val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
+//        val applicationName = "zio-test-" + UUID.randomUUID().toString
+//
+//        (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 2)).use {
+//          client =>
+//            for {
+//              _ <- putStrLn("Putting records")
+//              _ <- client
+//                     .putRecords(
+//                       streamName,
+//                       Serde.asciiString,
+//                       Seq(ProducerRecord("key1", "msg1"), ProducerRecord("key2", "msg2"))
+//                     )
+//                     .retry(retryOnResourceNotFound)
+//                     .provideLayer(Clock.live)
+//
+//              _ <- putStrLn("Starting dynamic consumer")
+//              _ <- LocalStackDynamicConsumer
+//                     .shardedStream(
+//                       streamName,
+//                       applicationName = applicationName,
+//                       deserializer = Serde.asciiString
+//                     )
+//                     .flatMapPar(Int.MaxValue)(_._2)
+//                     .take(2)
+//                     .tap(r => putStrLn(s"Got record $r") *> r.checkpoint.retry(Schedule.exponential(100.millis)))
+//                     .runCollect
+//            } yield assertCompletes
+//        }
+//      },
       testM("support multiple parallel streams") {
 
         val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
@@ -131,7 +131,7 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                      .runDrain
                      .fork
 
-              _ <- putStrLn("Starting dynamic consumer")
+              _ <- putStrLn("Starting dynamic consumers")
 
               records <- (streamConsumer("1")
                              merge ZStream

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -93,7 +93,7 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
               _  <- putStrLn(s"Consumer $label on fiber $id got record $r on shard $shardId")
             } yield ()
 
-          ZStream.fromEffect(putStrLn("Starting consumer ${label}")) *> LocalStackDynamicConsumer
+          ZStream.fromEffect(putStrLn(s"Starting consumer $label")) *> LocalStackDynamicConsumer
             .shardedStream(
               streamName,
               applicationName = applicationName,

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -44,38 +44,38 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
 
   override def spec =
     suite("DynamicConsumer")(
-//      testM("consume records produced on all shards produced on the stream") {
-//
-//        val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
-//        val applicationName = "zio-test-" + UUID.randomUUID().toString
-//
-//        (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 2)).use {
-//          client =>
-//            for {
-//              _ <- putStrLn("Putting records")
-//              _ <- client
-//                     .putRecords(
-//                       streamName,
-//                       Serde.asciiString,
-//                       Seq(ProducerRecord("key1", "msg1"), ProducerRecord("key2", "msg2"))
-//                     )
-//                     .retry(retryOnResourceNotFound)
-//                     .provideLayer(Clock.live)
-//
-//              _ <- putStrLn("Starting dynamic consumer")
-//              _ <- LocalStackDynamicConsumer
-//                     .shardedStream(
-//                       streamName,
-//                       applicationName = applicationName,
-//                       deserializer = Serde.asciiString
-//                     )
-//                     .flatMapPar(Int.MaxValue)(_._2)
-//                     .take(2)
-//                     .tap(r => putStrLn(s"Got record $r") *> r.checkpoint.retry(Schedule.exponential(100.millis)))
-//                     .runCollect
-//            } yield assertCompletes
-//        }
-//      },
+      testM("consume records produced on all shards produced on the stream") {
+
+        val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
+        val applicationName = "zio-test-" + UUID.randomUUID().toString
+
+        (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 2)).use {
+          client =>
+            for {
+              _ <- putStrLn("Putting records")
+              _ <- client
+                     .putRecords(
+                       streamName,
+                       Serde.asciiString,
+                       Seq(ProducerRecord("key1", "msg1"), ProducerRecord("key2", "msg2"))
+                     )
+                     .retry(retryOnResourceNotFound)
+                     .provideLayer(Clock.live)
+
+              _ <- putStrLn("Starting dynamic consumer")
+              _ <- LocalStackDynamicConsumer
+                     .shardedStream(
+                       streamName,
+                       applicationName = applicationName,
+                       deserializer = Serde.asciiString
+                     )
+                     .flatMapPar(Int.MaxValue)(_._2)
+                     .take(2)
+                     .tap(r => putStrLn(s"Got record $r") *> r.checkpoint.retry(Schedule.exponential(100.millis)))
+                     .runCollect
+            } yield assertCompletes
+        }
+      },
       testM("support multiple parallel streams") {
 
         val streamName      = "zio-test-stream-" + UUID.randomUUID().toString

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -105,7 +105,7 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                     handler(shardId, r) *>
                       (putStrLn(
                         s"Checkpointing at offset ${sequenceNumberForShard} in consumer ${label}, shard ${shardId}"
-                      ) *> r.checkpoint)
+                      ) *> r.checkpoint) // TODO this may fail when the shard lease has been stolen
                         .when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
                         .tapError(_ => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))
                 }.map(_._1)

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -105,7 +105,9 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                     handler(shardId, r) *>
                       (putStrLn(
                         s"Checkpointing at offset ${sequenceNumberForShard} in consumer ${label}, shard ${shardId}"
-                      ) *> r.checkpoint).when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
+                      ) *> r.checkpoint)
+                        .when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
+                        .tapError(e => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))
                 }.map(_._1)
                   .as((label, shardId))
                   .ensuring(putStrLn(s"Shard $shardId completed for consumer $label"))

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -107,7 +107,7 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                       (putStrLn(
                         s"Checkpointing at offset ${sequenceNumberForShard} in consumer ${label}, shard ${shardId}"
                       ) *> r.checkpoint.catchSome {
-                        case e: ShutdownException => // This will be throw when the shard lease has been stolen
+                        case _: ShutdownException => // This will be throw when the shard lease has been stolen
                           ZIO.unit
                       }).when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
                         .tapError(_ => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -13,7 +13,7 @@ import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio.{ Schedule, ZIO }
+import zio.{ Promise, Ref, Schedule, ZIO, ZManaged }
 
 object DynamicConsumerTest extends DefaultRunnableSpec {
   private val retryOnResourceNotFound: Schedule[Clock, Throwable, ((Throwable, Int), Duration)] =
@@ -24,7 +24,7 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
       Schedule.recurs(5) &&
       Schedule.exponential(2.second)
 
-  private val createStream = (streamName: String, nrShards: Int) =>
+  private def createStream(streamName: String, nrShards: Int): ZManaged[Console, Throwable, Unit] =
     for {
       adminClient <- AdminClient.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder)
       _           <- adminClient
@@ -43,112 +43,132 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
              }
     } yield ()
 
+  def testConsume1 =
+    testM("consume records produced on all shards produced on the stream") {
+      val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
+      val applicationName = "zio-test-" + UUID.randomUUID().toString
+
+      (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 2)).use { client =>
+        for {
+          _ <- putStrLn("Putting records")
+          _ <- client
+                 .putRecords(
+                   streamName,
+                   Serde.asciiString,
+                   Seq(ProducerRecord("key1", "msg1"), ProducerRecord("key2", "msg2"))
+                 )
+                 .retry(retryOnResourceNotFound)
+                 .provideLayer(Clock.live)
+
+          _ <- putStrLn("Starting dynamic consumer")
+          _ <- LocalStackDynamicConsumer
+                 .shardedStream(
+                   streamName,
+                   applicationName = applicationName,
+                   deserializer = Serde.asciiString
+                 )
+                 .flatMapPar(Int.MaxValue)(_._2)
+                 .take(2)
+                 .tap(r => putStrLn(s"Got record $r") *> r.checkpoint.retry(Schedule.exponential(100.millis)))
+                 .runCollect
+        } yield assertCompletes
+      }
+    }
+
+  def testConsume2 =
+    testM("support multiple parallel consumers on the same Kinesis stream") {
+
+      val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
+      val applicationName = "zio-test-" + UUID.randomUUID().toString
+
+      val nrRecords = 80
+
+      def streamConsumer(label: String, activeConsumers: Ref[Set[String]]) = {
+        val checkpointDivisor = 500
+
+        def handler(shardId: String, r: DynamicConsumer.Record[String]) =
+          for {
+            id <- ZIO.fiberId
+            _  <- putStrLn(s"Consumer $label on fiber $id got record $r on shard $shardId")
+          } yield ()
+
+        ZStream
+          .fromEffect(putStrLn(s"Starting consumer $label"))
+          .flatMap(_ =>
+            LocalStackDynamicConsumer
+              .shardedStream(
+                streamName,
+                applicationName = applicationName,
+                deserializer = Serde.asciiString
+              )
+              .flatMapPar(Int.MaxValue) {
+                case (shardId, shardStream) =>
+                  shardStream
+                    .tap(_ => activeConsumers.update(_ + label))
+                    .zipWithIndex
+                    .tap {
+                      case (r: DynamicConsumer.Record[String], sequenceNumberForShard: Long) =>
+                        handler(shardId, r).as(r) <*
+                          (putStrLn(
+                            s"Checkpointing at offset ${sequenceNumberForShard} in consumer ${label}, shard ${shardId}"
+                          ) *> r.checkpoint.catchSome {
+                            case _: ShutdownException => // This will be thrown when the shard lease has been stolen
+                              ZIO.unit
+                          }).when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
+                            .tapError(_ => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))
+                    }
+                    .as((label, shardId))
+                    .ensuring(putStrLn(s"Shard $shardId completed for consumer $label"))
+              }
+          )
+      }
+
+      (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 10)).use {
+        client =>
+          val records =
+            (1 to nrRecords).map(i => ProducerRecord(s"key$i", s"msg$i"))
+          for {
+            _                           <- putStrLn("Putting records")
+            _                           <- ZStream
+                   .fromIterable(1 to nrRecords)
+                   .schedule(Schedule.spaced(250.millis))
+                   .mapM { _ =>
+                     client
+                       .putRecords(streamName, Serde.asciiString, records)
+                       .tapError(e => putStrLn(s"error: $e").provideLayer(Console.live))
+                       .retry(retryOnResourceNotFound)
+                   }
+                   .provideSomeLayer(Clock.live)
+                   .runDrain
+                   .fork
+
+            _                           <- putStrLn("Starting dynamic consumers")
+            activeConsumers             <- Ref.make[Set[String]](Set.empty)
+            // Checke very second if all consumers got a shard lease to process
+            allConsumersGotAShard        = activeConsumers.get.map(_ == Set("1", "2"))
+            allConsumersGotAShardSignal <- Promise.make[Throwable, Unit]
+            _                           <- ZIO
+                   .whenM(allConsumersGotAShard)(allConsumersGotAShardSignal.succeed(()))
+                   .repeat(Schedule.fixed(1.second))
+                   .provideLayer(Clock.live)
+                   .fork
+
+            records                     <- (streamConsumer("1", activeConsumers)
+                           merge ZStream
+                             .fromEffect(sleep(5.seconds))
+                             .flatMap(_ => streamConsumer("2", activeConsumers)))
+                         .interruptWhen(allConsumersGotAShardSignal.await)
+                         .runCollect
+            // Both consumers should have gotten some records
+            usedConsumers                = records.map(_._1).toSet
+          } yield assert(usedConsumers)(equalTo(Set("1", "2")))
+      }
+    }
+
   override def spec =
     suite("DynamicConsumer")(
-      testM("consume records produced on all shards produced on the stream") {
-
-        val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
-        val applicationName = "zio-test-" + UUID.randomUUID().toString
-
-        (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 2)).use {
-          client =>
-            for {
-              _ <- putStrLn("Putting records")
-              _ <- client
-                     .putRecords(
-                       streamName,
-                       Serde.asciiString,
-                       Seq(ProducerRecord("key1", "msg1"), ProducerRecord("key2", "msg2"))
-                     )
-                     .retry(retryOnResourceNotFound)
-                     .provideLayer(Clock.live)
-
-              _ <- putStrLn("Starting dynamic consumer")
-              _ <- LocalStackDynamicConsumer
-                     .shardedStream(
-                       streamName,
-                       applicationName = applicationName,
-                       deserializer = Serde.asciiString
-                     )
-                     .flatMapPar(Int.MaxValue)(_._2)
-                     .take(2)
-                     .tap(r => putStrLn(s"Got record $r") *> r.checkpoint.retry(Schedule.exponential(100.millis)))
-                     .runCollect
-            } yield assertCompletes
-        }
-      },
-      testM("support multiple parallel consumers on the same Kinesis stream") {
-
-        val streamName      = "zio-test-stream-" + UUID.randomUUID().toString
-        val applicationName = "zio-test-" + UUID.randomUUID().toString
-
-        val nrRecords = 80
-
-        def streamConsumer(label: String) = {
-          val checkpointDivisor = 500
-
-          def handler(shardId: String, r: DynamicConsumer.Record[String]) =
-            for {
-              id <- ZIO.fiberId
-              _  <- putStrLn(s"Consumer $label on fiber $id got record $r on shard $shardId")
-            } yield ()
-
-          ZStream.fromEffect(putStrLn(s"Starting consumer $label")) *> LocalStackDynamicConsumer
-            .shardedStream(
-              streamName,
-              applicationName = applicationName,
-              deserializer = Serde.asciiString
-            )
-            .flatMapPar(Int.MaxValue) {
-              case (shardId, shardStream) =>
-                shardStream.zipWithIndex.tap {
-                  case (r: DynamicConsumer.Record[String], sequenceNumberForShard: Long) =>
-                    handler(shardId, r).as(r) <*
-                      (putStrLn(
-                        s"Checkpointing at offset ${sequenceNumberForShard} in consumer ${label}, shard ${shardId}"
-                      ) *> r.checkpoint.catchSome {
-                        case _: ShutdownException => // This will be throw when the shard lease has been stolen
-                          ZIO.unit
-                      }).when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
-                        .tapError(_ => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))
-                }.map(_._1)
-                  .as((label, shardId))
-                  .ensuring(putStrLn(s"Shard $shardId completed for consumer $label"))
-            }
-        }
-
-        (Client.build(LocalStackDynamicConsumer.kinesisAsyncClientBuilder) <* createStream(streamName, 10)).use {
-          client =>
-            val records =
-              (1 to nrRecords).map(i => ProducerRecord(s"key$i", s"msg$i"))
-            for {
-              _ <- putStrLn("Putting records")
-              _ <- ZStream
-                     .fromIterable(1 to nrRecords)
-                     .schedule(Schedule.spaced(250.millis))
-                     .mapM { _ =>
-                       client
-                         .putRecords(streamName, Serde.asciiString, records)
-                         .tapError(e => putStrLn(s"error: $e").provideLayer(Console.live))
-                         .retry(retryOnResourceNotFound)
-                     }
-                     .provideSomeLayer(Clock.live)
-                     .runDrain
-                     .fork
-
-              _ <- putStrLn("Starting dynamic consumers")
-
-              records      <- (streamConsumer("1")
-                             merge ZStream
-                               .fromEffect(sleep(5.seconds))
-                               .flatMap(_ => streamConsumer("2")))
-                           .take(nrRecords * nrRecords.toLong)
-                           .runCollect
-              // Both consumers should have gotten some records
-              usedConsumers = records.map(_._1).toSet
-            } yield assert(usedConsumers)(equalTo(Set("1", "2")))
-        }
-      }
+      testConsume1,
+      testConsume2
     ) @@ timeout(5.minute) @@ sequential
 
   def sleep(d: Duration) = ZIO.sleep(d).provideLayer(Clock.live)

--- a/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/DynamicConsumerTest.scala
@@ -107,7 +107,7 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                         s"Checkpointing at offset ${sequenceNumberForShard} in consumer ${label}, shard ${shardId}"
                       ) *> r.checkpoint)
                         .when(sequenceNumberForShard % checkpointDivisor == checkpointDivisor - 1)
-                        .tapError(e => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))
+                        .tapError(_ => putStrLn(s"Failed to checkpoint in consumer ${label}, shard ${shardId}"))
                 }.map(_._1)
                   .as((label, shardId))
                   .ensuring(putStrLn(s"Shard $shardId completed for consumer $label"))

--- a/src/test/scala/nl/vroste/zio/kinesis/client/LocalStackDynamicConsumer.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/LocalStackDynamicConsumer.scala
@@ -1,6 +1,7 @@
 package nl.vroste.zio.kinesis.client
 
 import java.net.URI
+import java.util.UUID
 
 import nl.vroste.zio.kinesis.client.serde.Deserializer
 import software.amazon.awssdk.auth.credentials.{
@@ -68,7 +69,8 @@ object LocalStackDynamicConsumer {
   def shardedStream[R, T](
     streamName: String,
     applicationName: String,
-    deserializer: Deserializer[R, T]
+    deserializer: Deserializer[R, T],
+    workerIdentifier: String = UUID.randomUUID().toString
   ): ZStream[Blocking with R, Throwable, (String, ZStream[Any, Throwable, DynamicConsumer.Record[T]])] =
     DynamicConsumer.shardedStream(
       streamName,
@@ -77,7 +79,8 @@ object LocalStackDynamicConsumer {
       kinesisAsyncClientBuilder,
       cloudWatchClientBuilder,
       dynamoDbClientBuilder,
-      isEnhancedFanOut = false
+      isEnhancedFanOut = false,
+      workerIdentifier = workerIdentifier
     )
 
 }


### PR DESCRIPTION
Await shard stream shutdown when KCL requests shutdown. For faster shutdown, any unprocessed items (more specifically: not pulled in yet by the shard stream) in the queue are cleared.

Also:
* Document exceptions on `Record.checkpoint`
* Add `workerIdentifier` parameter for better test-debugging
* Reduce work done in `unsafeRun` calls on KCL threads
* Handle 'lease lost during checkpointing' in tests
* Make consumer test more robust