### PR TITLE
Simplify layers PR a bit

### DIFF
--- a/src/main/scala/nl/vroste/zio/kinesis/client/AdminClient.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/AdminClient.scala
@@ -12,17 +12,14 @@ import zio.{ Has, Schedule, Task, ZLayer }
 object AdminClient {
 
   val live: ZLayer[Has[KinesisAsyncClient], Throwable, AdminClient] =
-    ZLayer.fromService[KinesisAsyncClient, AdminClient.Service] {
-      new AdminClientLive(_)
-    }
+    ZLayer.fromService[KinesisAsyncClient, AdminClient.Service](new AdminClientLive(_))
 
   /**
    * Client for administrative operations
    *
    * The interface is as close as possible to the natural ZIO variant of the KinesisAsyncClient interface,
    * with some noteable differences:
-   * - Methods working with records (consuming or producing) make use of Serdes for (de)serialization
-   * - Paginated APIs such as listShards are modeled as a Stream
+   * - Paginated APIs such as listStreams are modeled as a ZStream
    * - AWS SDK library method responses that only indicate success and do not contain any other
    *   data (besides SDK internals) are mapped to a ZIO of Unit
    * - AWS SDK library method responses that contain a single field are mapped to a ZIO of that field's type

--- a/src/main/scala/nl/vroste/zio/kinesis/client/Client.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/Client.scala
@@ -23,7 +23,7 @@ object Client {
    * The interface is as close as possible to the natural ZIO variant of the KinesisAsyncClient interface,
    * with some noteable differences:
    * - Methods working with records (consuming or producing) make use of Serdes for (de)serialization
-   * - Paginated APIs such as listShards are modeled as a Stream
+   * - Paginated APIs such as listShards are modeled as a ZStream
    * - AWS SDK library method responses that only indicate success and do not contain any other
    *   data (besides SDK internals) are mapped to a ZIO of Unit
    * - AWS SDK library method responses that contain a single field are mapped to a ZIO of that field's type

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -25,7 +25,7 @@ object DynamicConsumer {
     DynamicConsumer.Service
   ]] =
     ZLayer.fromServices[KinesisAsyncClient, CloudWatchAsyncClient, DynamoDbAsyncClient, DynamicConsumer.Service] {
-      DynamicConsumerLive.apply
+      new DynamicConsumerLive(_, _, _)
     }
 
   trait Service {

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
@@ -229,8 +229,3 @@ private[client] class DynamicConsumerLive(
 
   }
 }
-
-private[client] object DynamicConsumerLive {
-  def apply(kinesis: KinesisAsyncClient, cloudWatch: CloudWatchAsyncClient, dynamoDb: DynamoDbAsyncClient) =
-    new DynamicConsumerLive(kinesis, cloudWatch, dynamoDb)
-}

--- a/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
@@ -14,28 +14,16 @@ package object client {
   def kinesisAsyncClientLayer(
     builder: KinesisAsyncClientBuilder = KinesisAsyncClient.builder
   ): ZLayer[Any, Throwable, Has[KinesisAsyncClient]] =
-    ZLayer.fromManaged(ZManaged.fromAutoCloseable {
-      ZIO.effect(
-        builder.build
-      )
-    })
+    ZManaged.fromAutoCloseable(ZIO.effect(builder.build)).toLayer
 
   def cloudWatchAsyncClientLayer(
     builder: CloudWatchAsyncClientBuilder = CloudWatchAsyncClient.builder
   ): ZLayer[Any, Throwable, Has[CloudWatchAsyncClient]] =
-    ZLayer.fromManaged(ZManaged.fromAutoCloseable {
-      ZIO.effect(
-        builder.build
-      )
-    })
+    ZManaged.fromAutoCloseable(ZIO.effect(builder.build)).toLayer
 
   def dynamoDbAsyncClientLayer(
     builder: DynamoDbAsyncClientBuilder = DynamoDbAsyncClient.builder
   ): ZLayer[Any, Throwable, Has[DynamoDbAsyncClient]] =
-    ZLayer.fromManaged(ZManaged.fromAutoCloseable {
-      ZIO.effect(
-        builder.build
-      )
-    })
+    ZManaged.fromAutoCloseable(ZIO.effect(builder.build)).toLayer
 
 }

--- a/src/test/scala/nl/vroste/zio/kinesis/client/ExampleApp.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ExampleApp.scala
@@ -12,9 +12,8 @@ import zio.stream.{ ZStream, ZTransducer }
 import zio.{ Chunk, ExitCode, Schedule, ZIO }
 
 object ExampleApp extends zio.App {
-
-  private val clientLayer      = LocalStackServices.kinesisAsyncClientLayer >>> Client.live
-  private val adminClientLayer = LocalStackServices.kinesisAsyncClientLayer >>> AdminClient.live
+  private val env =
+    LocalStackServices.kinesisAsyncClientLayer >>> (Client.live ++ AdminClient.live ++ LocalStackServices.dynamicConsumerLayer)
 
   override def run(
     args: List[String]
@@ -59,7 +58,7 @@ object ExampleApp extends zio.App {
       _ <- putStrLn("Exiting app")
 
     } yield ExitCode.success
-  }.provideCustomLayer(adminClientLayer ++ clientLayer ++ LocalStackServices.dynamicConsumerLayer).orDie
+  }.provideCustomLayer(env).orDie
 
   def produceRecords(streamName: String, nrRecords: Int) =
     (for {

--- a/src/test/scala/nl/vroste/zio/kinesis/client/LocalStackServices.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/LocalStackServices.scala
@@ -17,6 +17,9 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.utils.AttributeMap
 import zio.{ Has, ZIO, ZLayer, ZManaged }
 
+/**
+ * Layers for connecting to a LocalStack (https://localstack.cloud/) environment on a local docker host
+ */
 object LocalStackServices {
 
   private val region: Region          = Region.of("us-east-1")


### PR DESCRIPTION
* Only one provideCustomLayer in DynamicConsumerTest
* Use ZManaged#toLayer (IntelliJ cannot infer the type, but the compiler can)
* Put all layers in ExampleApp and DynamicConsumerTest in 'env'
* Simplify creation of DynamicConsumerLive
* Fix a bit of docs