### PR TITLE
Do not use worker identifier as enhanced fanout consumer name

### DIFF
--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
@@ -148,7 +148,6 @@ private[client] class DynamicConsumerLive(
         new FanOutConfig(kinesisClient)
           .streamName(streamName)
           .applicationName(applicationName)
-          .consumerName(workerIdentifier)
       else
         new PollingConfig(streamName, kinesisClient)
 


### PR DESCRIPTION
One consumer per application is fine, no need for one consumer per worker

Resolves #232 