### PR TITLE
Fix checkpointing on shard ended

### DIFF
--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
@@ -107,8 +107,10 @@ private[client] class DynamicConsumerLive(
       override def leaseLost(leaseLostInput: LeaseLostInput): Unit =
         shardQueue.foreach(_.stop("lease lost"))
 
-      override def shardEnded(shardEndedInput: ShardEndedInput): Unit =
+      override def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
         shardQueue.foreach(_.stop("shard ended"))
+        shardEndedInput.checkpointer().checkpoint()
+      }
 
       override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit =
         shardQueue.foreach(_.stop("shutdown requested"))


### PR DESCRIPTION
It's necessary to call the checkpoint() method instead of checkpoint(seqNr, subSeqNr)