### PR TITLE
Resharding support in Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,14 @@ Features:
 * Deserialization of records to any data type
 * Checkpointing of records according to user-defined Schedules
 * Automatic checkpointing at shard stream shutdown due to error or interruption
-* Handling of Kinesis resource limits (throttling and backoff)
+* Handling changes in the number of shards (resharding) while running
+* Correct handling of Kinesis resource limits (throttling and backoff)
 * KCL compatible metrics publishing to CloudWatch
 * Compatibility for running alongside KCL consumers
 * Emission of diagnostic events for custom logging / metrics / testing
 * Manual or otherwise user-defined shard assignment strategy
 * Pluggable lease/checkpoint storage backend
-
-In comparison to the Kinesis Client Library, it has the advantages of:
-* Fast startup and shutdown (less than 500 ms vs 10+ seconds) due to ZIOs superior interruption & fiber coordination mechanisms + optimized startup sequence
+* Optimized startup + shutdown sequence
 
 
 ### Basic usage

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ When a worker is stopped, its leases are released so that other workers may pick
 
 ### Resharding
 
-Changing the stream's shard count, or _resharding_, is fully supported. When a shard is split or two shards are merged, before processing of the new shard starts, the parent shard(s) are processed until the end. When a worker detects the end of a shard it is processing, Kinesis will tell it the new (child) shards and their processing will start immediately after both parent shards have. 
+Changing the stream's shard count, or _resharding_, is fully supported while the consumer is active. When a shard is split or two shards are merged, before processing of the new shard starts, the parent shard(s) are processed until the end. When a worker detects the end of a shard it is processing, Kinesis will tell it the new (child) shards and their processing will start immediately after both parent shards have been completely processed. 
 
 When another worker is processing one of the parent shards, it may take a while for this to be detected.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Features:
 * Manual or otherwise user-defined shard assignment strategy
 * Pluggable lease/checkpoint storage backend
 
+In comparison to the Kinesis Client Library, it has the advantages of:
+* Fast startup and shutdown (less than 500 ms vs 10+ seconds) due to ZIOs superior interruption & fiber coordination mechanisms + optimized startup sequence
+
+
 ### Basic usage
 
 The following example shows a simple ZIO App that consumes from a stream, prints a record and periodically checkpoints.
@@ -158,6 +162,20 @@ When one worker fails or loses connectivity, the other workers will detect that 
 
 When a worker is stopped, its leases are released so that other workers may pick them up.
 
+### Resharding
+
+Changing the stream's shard count, or _resharding_, is fully supported. When a shard is split or two shards are merged, before processing of the new shard starts, the parent shard(s) are processed until the end. When a worker detects the end of a shard it is processing, Kinesis will tell it the new (child) shards and their processing will start immediately after both parent shards have. 
+
+When another worker is processing one of the parent shards, it may take a while for this to be detected.
+
+To ensure that no shard is left behind, the list of shards is refreshed periodically.
+
+### Consuming multiple Kinesis streams
+
+If you want to process more than one Kinesis stream, simply create more than one instance and ensure that the application name is unique per stream. The application name is used to create a lease table. Unique application names will create a lease table per stream, to ensure that shard IDs do not conflict. Unlike the KCL, which heavily uses threads, there should be no performance need to have multi-stream support built into `Consumer`.
+
+For example, if your application name is `"order_processing"` and you want to consume the streams `"orders"` and `"payments`", create one `Consumer` with the application name `"order_processing_orders"` and one `"order_processing_payments"`.
+
 ### Customization
 
 The following parameters can be customized:
@@ -194,15 +212,12 @@ Lease coordination and metrics are fully compatible for running along other KCL 
 ### Unsupported features
 
 Features that are supported by `DynamicConsumer` but not by `Consumer`:
-* Handling resharding (split and merged shards)  
-  As a workaround the workers will have to be restarted to start processing the new shards.
 * KPL record aggregation via Protobuf + subsequence number checkpointing  
   Users can manually deserialize records via Protobuf if desired. Kinesis streams has a at-least once model anyway, so the lack of subsequence number checkpointing does not break that.
 * DynamoDB lease table billing mode configuration  
-  This can be adjusted in AWS Console if desired.
+  This can be adjusted in AWS Console if desired or manually using the AWS DynamoDB SDK.
 * Some metrics  
   Not all metrics published by the KCL are implemented yet. Some of them are not applicable because of different implementations.
-
 
 ## Configuration
 The default environments for `Client`, `AdminClient`, `Consumer`, `DynamicConsumer` and `Producer` will use the [Default Credential/Region Provider](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html).
@@ -312,7 +327,6 @@ The interface is largely the same as `Consumer`, except for:
  * Retrying is not done automatically by DynamicConsumer's Checkpointer.
 
 Unlike `Consumer`, `DynamicConsumer` also supports:
-* Resharding
 * KPL record aggregation via Protobuf + subsequence number checkpointing
 * Full CloudWatch metrics publishing
 

--- a/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
@@ -4,8 +4,10 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.core.retry.RetryPolicy
 import software.amazon.awssdk.services.cloudwatch.{ CloudWatchAsyncClient, CloudWatchAsyncClientBuilder }
 import software.amazon.awssdk.services.dynamodb.{ DynamoDbAsyncClient, DynamoDbAsyncClientBuilder }
+import software.amazon.awssdk.services.kinesis.model.{ ChildShard, Shard }
 import software.amazon.awssdk.services.kinesis.{ KinesisAsyncClient, KinesisAsyncClientBuilder }
 import zio.{ Has, ZIO, ZLayer, ZManaged }
+import scala.jdk.CollectionConverters._
 
 package object client {
 
@@ -60,5 +62,26 @@ package object client {
     : ZLayer[Any, Throwable, Has[KinesisAsyncClient] with Has[CloudWatchAsyncClient] with Has[DynamoDbAsyncClient]] =
     HttpClient.make() >>>
       sdkClientsLayer
+
+  private[client] def childShardToShard(s: ChildShard): Shard = {
+    val parentShards = s.parentShards().asScala.toSeq
+
+    val builder = Shard
+      .builder()
+      .shardId(s.shardId())
+      .hashKeyRange(s.hashKeyRange())
+
+    if (parentShards.size == 2)
+      builder
+        .parentShardId(parentShards.head)
+        .adjacentParentShardId(parentShards(1))
+        .build()
+    else if (parentShards.size == 1)
+      builder
+        .parentShardId(parentShards.head)
+        .build()
+    else
+      throw new IllegalArgumentException(s"Unexpected nr of child chards: ${parentShards.size}")
+  }
 
 }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Checkpointer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Checkpointer.scala
@@ -13,7 +13,8 @@ import zio.stream.{ ZStream, ZTransducer }
 case object ShardLeaseLost
 
 private[zionative] trait CheckpointerInternal {
-  def markEndOfShard(lastSequenceNumber: ExtendedSequenceNumber): UIO[Unit]
+  def setMaxSequenceNumber(lastSequenceNumber: ExtendedSequenceNumber): UIO[Unit]
+  def markEndOfShard(): UIO[Unit]
 }
 
 /**

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Checkpointer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Checkpointer.scala
@@ -12,6 +12,10 @@ import zio.stream.{ ZStream, ZTransducer }
  */
 case object ShardLeaseLost
 
+private[zionative] trait CheckpointerInternal {
+  def markEndOfShard(lastSequenceNumber: ExtendedSequenceNumber): UIO[Unit]
+}
+
 /**
  * Staging area for checkpoints
  *

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -338,7 +338,7 @@ object Consumer {
         .parentShardId(parentShards.head)
         .build()
     else
-      throw new IllegalArgumentException(s"Unexpected nr of child chards: ${parentShards.size}")
+      throw new IllegalArgumentException(s"Unexpected nr of parent shards: ${parentShards.size}")
   }
 
   val defaultEnvironment

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -361,7 +361,7 @@ object Consumer {
       }
   }
 
-  private val checkpointToShardIteratorType
+  private[zionative] val checkpointToShardIteratorType
     : (Either[SpecialCheckpoint, ExtendedSequenceNumber], InitialPosition) => ShardIteratorType = {
     case (Left(SpecialCheckpoint.TrimHorizon), _)                                      => ShardIteratorType.TrimHorizon
     case (Left(SpecialCheckpoint.Latest), _)                                           => ShardIteratorType.Latest

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -26,8 +26,6 @@ import zio.logging.{ log, Logging }
 import zio.random.Random
 import zio.stream.ZStream
 
-import scala.jdk.CollectionConverters._
-
 final case class ExtendedSequenceNumber(sequenceNumber: String, subSequenceNumber: Long)
 
 sealed trait FetchMode

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -275,7 +275,6 @@ object Consumer {
                                           s"Found end of shard for ${shardId}. " +
                                             s"Child shards are ${childShards.map(_.shardId()).mkString(", ")}"
                                         ) *>
-                                          // TODO can we pick up leases for this shard somehow?
                                           checkpointer.markEndOfShard() *>
                                           leaseCoordinator.childShardsDetected(childShards)
                                       ) *> ZStream.empty

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -274,7 +274,10 @@ object Consumer {
                                         ZStream.fail(e)
                                     case Right(EndOfShard(childShards @ _)) =>
                                       ZStream.fromEffect(
-                                        log.debug(s"Found end of shard for ${shardId}!!") *>
+                                        log.debug(
+                                          s"Found end of shard for ${shardId}. " +
+                                            s"Child shards are ${childShards.map(_.shardId()).mkString(", ")}"
+                                        ) *>
                                           // TODO can we pick up leases for this shard somehow?
                                           checkpointer.markEndOfShard() *>
                                           leaseCoordinator.childShardsDetected(childShards)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -270,9 +270,6 @@ object Consumer {
                                         records.lastOption.fold(ZIO.unit) { r =>
                                           val extendedSequenceNumber =
                                             ExtendedSequenceNumber(r.sequenceNumber, r.subSequenceNumber)
-                                          println(
-                                            s"Shard ${shardId} setting high watermark to ${extendedSequenceNumber}"
-                                          )
                                           checkpointer.setMaxSequenceNumber(extendedSequenceNumber)
                                         }
                                       }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
@@ -21,10 +21,15 @@ object DiagnosticEvent {
   final case class PollComplete(shardId: String, nrRecords: Int, behindLatest: Duration, duration: Duration)
       extends DiagnosticEvent
 
+  sealed trait ShardEvent extends DiagnosticEvent
+
   /**
    * A shard has ended and the last record has been checkpointed
    */
-  final case class ShardEnded(shard: String) extends DiagnosticEvent
+  final case class ShardEnded(shard: String) extends ShardEvent
+
+  // TODO
+  final case class NewShardDetected(shard: String) extends ShardEvent
 
   /**
    * Enhanced fanout produced a batch of records

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
@@ -39,7 +39,8 @@ object DiagnosticEvent {
     * @param shardId Shard ID
    * @param checkpoint The last checkpoint made for this shard
    */
-  final case class LeaseAcquired(shardId: String, checkpoint: Option[ExtendedSequenceNumber]) extends LeaseEvent
+  final case class LeaseAcquired(shardId: String, checkpoint: Option[Either[SpecialCheckpoint, ExtendedSequenceNumber]])
+      extends LeaseEvent
 
   /**
    * The worker discovered that it had lost the lease for the given shard
@@ -71,7 +72,8 @@ object DiagnosticEvent {
     * @param shardId Shard ID
    * @param checkpoint Checkpoint
    */
-  final case class Checkpoint(shardId: String, checkpoint: ExtendedSequenceNumber) extends LeaseEvent
+  final case class Checkpoint(shardId: String, checkpoint: Either[SpecialCheckpoint, ExtendedSequenceNumber])
+      extends LeaseEvent
 
   sealed trait WorkerEvent extends DiagnosticEvent
 

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
@@ -22,6 +22,11 @@ object DiagnosticEvent {
       extends DiagnosticEvent
 
   /**
+   * A shard has ended and the last record has been checkpointed
+   */
+  final case class ShardEnded(shard: String) extends DiagnosticEvent
+
+  /**
    * Enhanced fanout produced a batch of records
    *
         * @param shardId

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/DiagnosticEvent.scala
@@ -28,7 +28,6 @@ object DiagnosticEvent {
    */
   final case class ShardEnded(shard: String) extends ShardEvent
 
-  // TODO
   final case class NewShardDetected(shard: String) extends ShardEvent
 
   /**

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Fetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Fetcher.scala
@@ -22,7 +22,7 @@ private[zionative] trait Fetcher {
 }
 
 private[zionative] object Fetcher {
-  case class EndOfShard(lastSequenceNumber: ExtendedSequenceNumber, childShards: Seq[ChildShard])
+  case class EndOfShard(childShards: Seq[ChildShard])
 
   def apply(
     f: (

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Fetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Fetcher.scala
@@ -1,6 +1,6 @@
 package nl.vroste.zio.kinesis.client.zionative
 import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
-import software.amazon.awssdk.services.kinesis.model.{ Record => KinesisRecord }
+import software.amazon.awssdk.services.kinesis.model.{ ChildShard, Record => KinesisRecord }
 import zio.clock.Clock
 import zio.stream.ZStream
 
@@ -12,10 +12,15 @@ private[zionative] trait Fetcher {
    *
    * May complete when the shard ends
    */
-  def shardRecordStream(shardId: String, startingPosition: ShardIteratorType): ZStream[Clock, Throwable, KinesisRecord]
+  def shardRecordStream(
+    shardId: String,
+    startingPosition: ShardIteratorType
+  ): ZStream[Clock, Either[Throwable, Seq[ChildShard]], KinesisRecord]
 }
 
 private[zionative] object Fetcher {
-  def apply(f: (String, ShardIteratorType) => ZStream[Clock, Throwable, KinesisRecord]): Fetcher =
+  def apply(
+    f: (String, ShardIteratorType) => ZStream[Clock, Either[Throwable, Seq[ChildShard]], KinesisRecord]
+  ): Fetcher =
     (shard, startingPosition) => f(shard, startingPosition)
 }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Fetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Fetcher.scala
@@ -1,7 +1,7 @@
 package nl.vroste.zio.kinesis.client.zionative
 import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
-import software.amazon.awssdk.services.kinesis.model.{ ChildShard, Record => KinesisRecord }
+import software.amazon.awssdk.services.kinesis.model.{ Shard, Record => KinesisRecord }
 import zio.clock.Clock
 import zio.stream.ZStream
 
@@ -22,7 +22,7 @@ private[zionative] trait Fetcher {
 }
 
 private[zionative] object Fetcher {
-  case class EndOfShard(childShards: Seq[ChildShard])
+  case class EndOfShard(childShards: Seq[Shard])
 
   def apply(
     f: (

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
@@ -3,6 +3,7 @@ import nl.vroste.zio.kinesis.client.zionative.LeaseCoordinator.AcquiredLease
 import software.amazon.awssdk.services.kinesis.model.Shard
 import zio.clock.Clock
 import zio.logging.Logging
+import zio.random.Random
 import zio.stream.ZStream
 import zio.{ Promise, UIO, ZIO }
 
@@ -14,6 +15,8 @@ private[zionative] trait LeaseCoordinator {
   def acquiredLeases: ZStream[Clock, Throwable, AcquiredLease]
 
   def updateShards(shards: Map[String, Shard]): UIO[Unit]
+
+  def childShardsDetected(childShards: Seq[Shard]): ZIO[Clock with Logging with Random, Throwable, Unit]
 }
 
 private[zionative] object LeaseCoordinator {

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
@@ -6,9 +6,9 @@ import zio.stream.ZStream
 import zio.{ Promise, UIO, ZIO }
 
 private[zionative] trait LeaseCoordinator {
-  def makeCheckpointer(shardId: String): ZIO[Clock with Logging, Throwable, Checkpointer]
+  def makeCheckpointer(shardId: String): ZIO[Clock with Logging, Throwable, Checkpointer with CheckpointerInternal]
 
-  def getCheckpointForShard(shardId: String): UIO[Option[ExtendedSequenceNumber]]
+  def getCheckpointForShard(shardId: String): UIO[Option[Either[SpecialCheckpoint, ExtendedSequenceNumber]]]
 
   def acquiredLeases: ZStream[Clock, Throwable, AcquiredLease]
 }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
@@ -1,5 +1,6 @@
 package nl.vroste.zio.kinesis.client.zionative
 import nl.vroste.zio.kinesis.client.zionative.LeaseCoordinator.AcquiredLease
+import software.amazon.awssdk.services.kinesis.model.Shard
 import zio.clock.Clock
 import zio.logging.Logging
 import zio.stream.ZStream
@@ -11,6 +12,8 @@ private[zionative] trait LeaseCoordinator {
   def getCheckpointForShard(shardId: String): UIO[Option[Either[SpecialCheckpoint, ExtendedSequenceNumber]]]
 
   def acquiredLeases: ZStream[Clock, Throwable, AcquiredLease]
+
+  def updateShards(shards: Map[String, Shard]): UIO[Unit]
 }
 
 private[zionative] object LeaseCoordinator {

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseRepository.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseRepository.scala
@@ -5,12 +5,26 @@ import zio.clock.Clock
 import zio.logging.Logging
 import zio.stream.ZStream
 
+sealed trait SpecialCheckpoint {
+  val stringValue: String
+}
+
+object SpecialCheckpoint {
+  case object ShardEnd extends SpecialCheckpoint {
+    val stringValue = "SHARD_END"
+  }
+
+  case object TrimHorizon extends SpecialCheckpoint {
+    val stringValue = "TRIM_HORIZON"
+  }
+}
+
 object LeaseRepository {
   final case class Lease(
     key: String,
     owner: Option[String],
     counter: Long,
-    checkpoint: Option[ExtendedSequenceNumber],
+    checkpoint: Option[Either[SpecialCheckpoint, ExtendedSequenceNumber]],
     parentShardIds: Seq[String]
   ) {
     def increaseCounter: Lease = copy(counter = counter + 1)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseRepository.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseRepository.scala
@@ -47,6 +47,8 @@ object LeaseRepository {
      */
     def createLeaseTableIfNotExists(tableName: String): ZIO[Clock with Logging, Throwable, Boolean]
 
+    def deleteTable(tableName: String): ZIO[Clock with Logging, Throwable, Unit]
+
     def getLeases(tableName: String): ZStream[Clock, Throwable, Lease]
 
     /**

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseRepository.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseRepository.scala
@@ -17,6 +17,14 @@ object SpecialCheckpoint {
   case object TrimHorizon extends SpecialCheckpoint {
     val stringValue = "TRIM_HORIZON"
   }
+
+  case object Latest extends SpecialCheckpoint {
+    val stringValue = "LATEST"
+  }
+
+  case object AtTimestamp extends SpecialCheckpoint {
+    val stringValue = "AT_TIMESTAMP"
+  }
 }
 
 object LeaseRepository {

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategy.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategy.scala
@@ -85,9 +85,10 @@ object ShardAssignmentStrategy {
           now          <- zio.clock.currentDateTime.map(_.toInstant()).orDie
           expiredLeases = leases.collect {
                             case (lease, lastUpdated)
-                                if lastUpdated.isBefore(now.minusMillis(expirationTime.toMillis)) =>
+                                if lastUpdated.isBefore(now.minusMillis(expirationTime.toMillis)) &&
+                                  !lease.checkpoint.contains(Left(SpecialCheckpoint.ShardEnd)) =>
                               lease
-                          }.toSet
+                          }
           _            <- log.info(s"Found expired leases: ${expiredLeases.map(_.key).mkString(",")}").when(expiredLeases.nonEmpty)
 
           shardsWithoutLease = shards.filterNot(shard => leases.map(_._1.key).toList.contains(shard))

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategy.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategy.scala
@@ -44,7 +44,8 @@ object ShardAssignmentStrategy {
    * Note that users must make sure that other workers in the pool also use a manual shard assignment
    * strategy, otherwise stealing back of leases by other workers may occur.
    *
-   * You also need to make sure that all shards are covered by the shard assignment of all workers
+   * You also need to make sure that all shards are covered by the shard assignment of all workers.
+   * After resharding, the list of shards must be reconfigured.
    *
    * @param shardAssignment IDs of shards to assign to this worker
    */

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
@@ -64,13 +64,11 @@ object EnhancedFanOutFetcher {
             .retry(config.retrySchedule)
         }.mapError(Left(_): Either[Throwable, EndOfShard])
           .flatMap { response =>
-            if (response.hasChildShards) {
-              val lastRecord     = response.records().asScala.last
-              val lastSequenceNr = ExtendedSequenceNumber(lastRecord.sequenceNumber(), 0L)
+            if (response.hasChildShards)
               ZStream.succeed(response) ++ ZStream.fail(
-                Right(EndOfShard(lastSequenceNr, response.childShards().asScala.toSeq))
+                Right(EndOfShard(response.childShards().asScala.toSeq))
               )
-            } else
+            else
               ZStream.succeed(response)
           }
           .mapConcat(_.records.asScala)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
@@ -3,7 +3,7 @@ package nl.vroste.zio.kinesis.client.zionative.fetcher
 import nl.vroste.zio.kinesis.client.AdminClient.StreamDescription
 import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
-import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, ExtendedSequenceNumber, FetchMode, Fetcher }
+import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, FetchMode, Fetcher }
 import nl.vroste.zio.kinesis.client.{ Client, Util }
 import software.amazon.awssdk.services.kinesis.model.{ ConsumerStatus, ResourceInUseException }
 import zio._

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
@@ -2,9 +2,10 @@ package nl.vroste.zio.kinesis.client.zionative.fetcher
 
 import nl.vroste.zio.kinesis.client.AdminClient.StreamDescription
 import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
+import nl.vroste.zio.kinesis.client.zionative.Consumer.childShardToShard
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
 import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, FetchMode, Fetcher }
-import nl.vroste.zio.kinesis.client.{ childShardToShard, Client, Util }
+import nl.vroste.zio.kinesis.client.{ Client, Util }
 import software.amazon.awssdk.services.kinesis.model.{ ConsumerStatus, ResourceInUseException }
 import zio._
 import zio.clock.Clock

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
@@ -4,7 +4,7 @@ import nl.vroste.zio.kinesis.client.AdminClient.StreamDescription
 import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
 import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, FetchMode, Fetcher }
-import nl.vroste.zio.kinesis.client.{ Client, Util }
+import nl.vroste.zio.kinesis.client.{ childShardToShard, Client, Util }
 import software.amazon.awssdk.services.kinesis.model.{ ConsumerStatus, ResourceInUseException }
 import zio._
 import zio.clock.Clock
@@ -66,7 +66,7 @@ object EnhancedFanOutFetcher {
           .flatMap { response =>
             if (response.hasChildShards)
               ZStream.succeed(response) ++ ZStream.fail(
-                Right(EndOfShard(response.childShards().asScala.toSeq))
+                Right(EndOfShard(response.childShards().asScala.map(childShardToShard).toSeq))
               )
             else
               ZStream.succeed(response)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
@@ -5,7 +5,7 @@ import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
 import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, ExtendedSequenceNumber, FetchMode, Fetcher }
 import nl.vroste.zio.kinesis.client.{ Client, Util }
-import software.amazon.awssdk.services.kinesis.model.{ ChildShard, ConsumerStatus, ResourceInUseException }
+import software.amazon.awssdk.services.kinesis.model.{ ConsumerStatus, ResourceInUseException }
 import zio._
 import zio.clock.Clock
 import zio.duration._

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/EnhancedFanOutFetcher.scala
@@ -2,7 +2,8 @@ package nl.vroste.zio.kinesis.client.zionative.fetcher
 
 import nl.vroste.zio.kinesis.client.AdminClient.StreamDescription
 import nl.vroste.zio.kinesis.client.Client.ShardIteratorType
-import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, FetchMode, Fetcher }
+import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
+import nl.vroste.zio.kinesis.client.zionative.{ DiagnosticEvent, ExtendedSequenceNumber, FetchMode, Fetcher }
 import nl.vroste.zio.kinesis.client.{ Client, Util }
 import software.amazon.awssdk.services.kinesis.model.{ ChildShard, ConsumerStatus, ResourceInUseException }
 import zio._
@@ -61,11 +62,15 @@ object EnhancedFanOutFetcher {
             // Retry on connection loss, throttling exception, etc.
             // Note that retry has to be at this level, not the outermost ZStream because that reinitializes the start position
             .retry(config.retrySchedule)
-        }.mapError(Left(_): Either[Throwable, Seq[ChildShard]])
+        }.mapError(Left(_): Either[Throwable, EndOfShard])
           .flatMap { response =>
-            if (response.hasChildShards)
-              ZStream.succeed(response) ++ ZStream.fail(Right(response.childShards().asScala.toSeq))
-            else
+            if (response.hasChildShards) {
+              val lastRecord     = response.records().asScala.last
+              val lastSequenceNr = ExtendedSequenceNumber(lastRecord.sequenceNumber(), 0L)
+              ZStream.succeed(response) ++ ZStream.fail(
+                Right(EndOfShard(lastSequenceNr, response.childShards().asScala.toSeq))
+              )
+            } else
               ZStream.succeed(response)
           }
           .mapConcat(_.records.asScala)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
@@ -1,7 +1,8 @@
 package nl.vroste.zio.kinesis.client.zionative.fetcher
+import nl.vroste.zio.kinesis.client.zionative.Consumer.childShardToShard
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
 import nl.vroste.zio.kinesis.client.zionative.{ Consumer, DiagnosticEvent, FetchMode, Fetcher }
-import nl.vroste.zio.kinesis.client.{ childShardToShard, Client, Util }
+import nl.vroste.zio.kinesis.client.{ Client, Util }
 import zio._
 import zio.clock.Clock
 import zio.duration._

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
@@ -2,7 +2,6 @@ package nl.vroste.zio.kinesis.client.zionative.fetcher
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
 import nl.vroste.zio.kinesis.client.zionative.{ Consumer, DiagnosticEvent, ExtendedSequenceNumber, FetchMode, Fetcher }
 import nl.vroste.zio.kinesis.client.{ Client, Util }
-import software.amazon.awssdk.services.kinesis.model.ChildShard
 import zio._
 import zio.clock.Clock
 import zio.duration._

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
@@ -1,6 +1,6 @@
 package nl.vroste.zio.kinesis.client.zionative.fetcher
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
-import nl.vroste.zio.kinesis.client.zionative.{ Consumer, DiagnosticEvent, ExtendedSequenceNumber, FetchMode, Fetcher }
+import nl.vroste.zio.kinesis.client.zionative.{ Consumer, DiagnosticEvent, FetchMode, Fetcher }
 import nl.vroste.zio.kinesis.client.{ Client, Util }
 import zio._
 import zio.clock.Clock

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
@@ -37,6 +37,9 @@ object PollingFetcher {
     } yield Fetcher { (shardId, startingPosition) =>
       ZStream.unwrapManaged {
         for {
+          _                    <- log
+                 .info(s"Creating PollingFetcher for shard ${shardId} with starting position ${startingPosition}")
+                 .toManaged_
           initialShardIterator <- getShardIterator(streamName, shardId, startingPosition)
                                     .retry(retryOnThrottledWithSchedule(config.throttlingBackoff))
                                     .mapError(Left(_): Either[Throwable, EndOfShard])

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/fetcher/PollingFetcher.scala
@@ -1,7 +1,7 @@
 package nl.vroste.zio.kinesis.client.zionative.fetcher
 import nl.vroste.zio.kinesis.client.zionative.Fetcher.EndOfShard
 import nl.vroste.zio.kinesis.client.zionative.{ Consumer, DiagnosticEvent, FetchMode, Fetcher }
-import nl.vroste.zio.kinesis.client.{ Client, Util }
+import nl.vroste.zio.kinesis.client.{ childShardToShard, Client, Util }
 import zio._
 import zio.clock.Clock
 import zio.duration._
@@ -90,7 +90,9 @@ object PollingFetcher {
                               ZStream.succeed(response) ++ (ZStream.fromEffect(
                                 log.debug(s"PollingFetcher found end of shard for ${shardId}")
                               ) *>
-                                ZStream.fail(Right(EndOfShard(response.childShards().asScala.toSeq))))
+                                ZStream.fail(
+                                  Right(EndOfShard(response.childShards().asScala.map(childShardToShard).toSeq))
+                                ))
                             else
                               ZStream.succeed(response)
                           }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -652,7 +652,7 @@ object DefaultLeaseCoordinator {
   /**
    *
    * @param currentLeases Latest known state of all leases
-   * @param shards List of all of the stream's shards
+   * @param shards List of all of the stream's shards which are currently active
    */
   final case class State(
     currentLeases: Map[String, LeaseState],

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -2,7 +2,6 @@ package nl.vroste.zio.kinesis.client.zionative.leasecoordinator
 
 import java.time.{ DateTimeException, Instant }
 
-import scala.collection.compat._
 import nl.vroste.zio.kinesis.client.Record
 import nl.vroste.zio.kinesis.client.zionative.LeaseCoordinator.AcquiredLease
 import nl.vroste.zio.kinesis.client.zionative._
@@ -515,7 +514,7 @@ private class DefaultLeaseCoordinator(
         }) *> log.debug("releaseLeases done")
 }
 
-object DefaultLeaseCoordinator {
+private[zionative] object DefaultLeaseCoordinator {
 
   /**
    * Commands relating to leases that need to be executed non-concurrently per lease, because

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -479,10 +479,8 @@ private class DefaultLeaseCoordinator(
       override def setMaxSequenceNumber(lastSequenceNumber: ExtendedSequenceNumber): UIO[Unit] =
         maxSequenceNumber.set(Some(lastSequenceNumber))
 
-      override def markEndOfShard(): UIO[Unit] = {
-        println(s"Marking end of shard for ${shardId}")
+      override def markEndOfShard(): UIO[Unit] =
         shardEnded.set(true)
-      }
     }
 
   def releaseLeases: ZIO[Logging with Clock, Nothing, Unit] =

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -96,7 +96,7 @@ private class DefaultLeaseCoordinator(
              stateBefore.currentLeases.map(_._2.lease),
              stateAfter.currentLeases.map(_._2.lease)
            )
-      newShards                 = stateAfter.shards.keySet -- stateBefore.shards.keySet
+      newShards                 = (stateAfter.shards.keySet -- stateBefore.shards.keySet).filter(_ => stateBefore.shards.nonEmpty)
       removedShards             = stateBefore.shards.keySet -- stateAfter.shards.keySet
       _                        <- ZIO.foreach(newShards)(shardId => emitDiagnostic(DiagnosticEvent.NewShardDetected(shardId)))
       _                        <- ZIO.foreach(removedShards)(shardId => emitDiagnostic(DiagnosticEvent.ShardEnded(shardId)))

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -70,7 +70,7 @@ private class DefaultLeaseCoordinator(
 
   val now = zio.clock.currentDateTime.map(_.toInstant())
 
-  private def updateShards(shards: Map[String, Shard]): UIO[Unit] =
+  def updateShards(shards: Map[String, Shard]): UIO[Unit] =
     state.update(_.updateShards(shards))
 
   /**

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -368,7 +368,7 @@ private class DefaultLeaseCoordinator(
                      case (shardId, s) =>
                        !leases.toSeq.exists(l =>
                          l.lease.key == shardId && shardHasEnded(l.lease)
-                       ) && parentShardsCompleted(s, shards, leases.map(_.lease))
+                       ) && parentShardsCompleted(s, leases.map(_.lease))
                    }
       desiredShards <- strategy.desiredShards(openLeases, openShards.keySet, workerId)
       _             <- log.info(s"Desired shard assignment: ${desiredShards.mkString(",")}")
@@ -395,7 +395,7 @@ private class DefaultLeaseCoordinator(
 
   private def shardHasEnded(l: Lease) = l.checkpoint.contains(Left(SpecialCheckpoint.ShardEnd))
 
-  private def parentShardsCompleted(shard: Shard, shards: Map[String, Shard], leases: Set[Lease]): Boolean = {
+  private def parentShardsCompleted(shard: Shard, leases: Set[Lease]): Boolean = {
     val parentShardIds = Option(shard.parentShardId()).toList ++ Option(shard.adjacentParentShardId()).toList
 
 //    println(

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -692,8 +692,6 @@ object DefaultLeaseCoordinator {
 
     def updateShards(shards: Map[String, Shard]): State = copy(shards = shards)
 
-    def removeShard(id: String): State = copy(shards = shards - id)
-
     def updateLease(lease: Lease, now: Instant): State =
       updateLeases(List(lease), now)
 

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/LeaseCoordinationSettings.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/LeaseCoordinationSettings.scala
@@ -20,6 +20,7 @@ import zio.clock.Clock
  * @param releaseLeaseTimeout Time after which releasing a lease is silently aborted.
  * @param renewRetrySchedule Schedule that controls retries when exceptions occur when renewing a
  *                           lease. The lease is released (internally only) when the schedule fails.
+ * @param shardRefreshInterval Interval at which the stream's shards are refreshed
  */
 final case class LeaseCoordinationSettings(
   renewInterval: Duration = 3.seconds,
@@ -28,5 +29,6 @@ final case class LeaseCoordinationSettings(
   maxParallelLeaseRenewals: Int = 10,
   releaseLeaseTimeout: Duration = 10.seconds,
   renewRetrySchedule: Schedule[Clock, Throwable, Any] =
-    Util.exponentialBackoff(3.second, 30.seconds, maxRecurs = Some(3))
+    Util.exponentialBackoff(3.second, 30.seconds, maxRecurs = Some(3)),
+  shardRefreshInterval: Duration = 30.seconds
 )

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/ZioExtensions.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/ZioExtensions.scala
@@ -3,7 +3,7 @@ import zio.{ Cause, Exit, URIO, ZIO }
 
 object ZioExtensions {
   implicit class OnSuccessSyntax[R, E, A](val zio: ZIO[R, E, A]) extends AnyVal {
-    final def onSuccess(cleanup: A => URIO[R, Any]): ZIO[R, E, A] =
+    final def onSuccess[R1 <: R](cleanup: A => URIO[R1, Any]): ZIO[R1, E, A] =
       zio.onExit {
         case Exit.Success(a) => cleanup(a)
         case _               => ZIO.unit

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leaserepository/DynamoDbLeaseRepository.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leaserepository/DynamoDbLeaseRepository.scala
@@ -270,6 +270,15 @@ private class DynamoDbLeaseRepository(client: DynamoDbAsyncClient, timeout: Dura
       }
   }
 
+  override def deleteTable(
+    tableName: String
+  ): ZIO[Clock with Logging, Throwable, Unit] = {
+    val request = DeleteTableRequest.builder().tableName(tableName).build()
+    asZIO(client.deleteTable(request))
+      .timeoutFail(new TimeoutException(s"Timeout creating lease"))(timeout)
+      .unit
+  }
+
   private def toLease(item: DynamoDbItem): Try[Lease] =
     Try {
       Lease(

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/metrics/CloudWatchMetricsPublisher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/metrics/CloudWatchMetricsPublisher.scala
@@ -87,6 +87,7 @@ private class CloudWatchMetricsPublisher(
           )
         )
       case LeaseReleased(shardId @ _)                               => List.empty // Processed in periodic metrics
+      case ShardEnded(shard @ _)                                    => List.empty
       case Checkpoint(shardId @ _, checkpoint @ _)                  => List.empty
       case WorkerJoined(workerId @ _)                               => List.empty // Processed in periodic metrics
       case WorkerLeft(workerId @ _)                                 => List.empty // Processed in periodic metrics
@@ -136,6 +137,7 @@ private class CloudWatchMetricsPublisher(
       case ShardLeaseLost(shardId)   => heldLeases.update(_ - shardId)
       case LeaseRenewed(_, _)        => UIO.unit
       case LeaseReleased(shardId)    => heldLeases.update(_ - shardId)
+      case ShardEnded(_)             => UIO.unit
       case Checkpoint(_, _)          => UIO.unit
       case WorkerJoined(workerId)    => workers.update(_ + workerId)
       case WorkerLeft(workerId)      => workers.update(_ - workerId)

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/metrics/CloudWatchMetricsPublisher.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/metrics/CloudWatchMetricsPublisher.scala
@@ -87,6 +87,7 @@ private class CloudWatchMetricsPublisher(
           )
         )
       case LeaseReleased(shardId @ _)                               => List.empty // Processed in periodic metrics
+      case NewShardDetected(shardId @ _)                            => List.empty
       case ShardEnded(shard @ _)                                    => List.empty
       case Checkpoint(shardId @ _, checkpoint @ _)                  => List.empty
       case WorkerJoined(workerId @ _)                               => List.empty // Processed in periodic metrics
@@ -138,6 +139,7 @@ private class CloudWatchMetricsPublisher(
       case LeaseRenewed(_, _)        => UIO.unit
       case LeaseReleased(shardId)    => heldLeases.update(_ - shardId)
       case ShardEnded(_)             => UIO.unit
+      case NewShardDetected(_)       => UIO.unit
       case Checkpoint(_, _)          => UIO.unit
       case WorkerJoined(workerId)    => workers.update(_ + workerId)
       case WorkerLeft(workerId)      => workers.update(_ - workerId)

--- a/src/test/scala/nl/vroste/zio/kinesis/client/ExampleApp.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ExampleApp.scala
@@ -21,14 +21,14 @@ import zio.stream.{ ZStream, ZTransducer }
  * Example app that shows the ZIO-native and KCL workers running in parallel
  */
 object ExampleApp extends zio.App {
-  val streamName                      = "zio-test-stream-16" // + java.util.UUID.randomUUID().toString
+  val streamName                      = "zio-test-stream-17" // + java.util.UUID.randomUUID().toString
   val nrRecords                       = 2000000
   val produceRate                     = 10                   // Nr records to produce per second
   val nrShards                        = 2
   val enhancedFanout                  = false
-  val nrNativeWorkers                 = 1
+  val nrNativeWorkers                 = 2
   val nrKclWorkers                    = 0
-  val applicationName                 = "testApp-5"          // + java.util.UUID.randomUUID().toString(),
+  val applicationName                 = "testApp-6"          // + java.util.UUID.randomUUID().toString(),
   val runtime                         = 3.minute
   val maxRandomWorkerStartDelayMillis = 1 + 0 * 60 * 1000
   val recordProcessingTime: Duration  = 1.millisecond

--- a/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
@@ -13,16 +13,15 @@ object TestUtil {
   ): ZIO[AdminClient with Client with Clock with Console with R, Throwable, A] =
     TestUtil
       .createStream(name, shards)
-      .tapM { _ =>
-        def getShards: ZIO[Client with Clock, Throwable, Chunk[Shard]] =
-          ZIO
-            .service[Client.Service]
-            .flatMap(_.listShards(name).runCollect)
-            .filterOrElse(_.nonEmpty)(_ => getShards.delay(1.second))
-            .catchSome { case _: ResourceInUseException => getShards.delay(1.second) }
-        getShards
-      }
+      .tapM(_ => getShards(name))
       .use_(f)
+
+  def getShards(name: String): ZIO[Client with Clock, Throwable, Chunk[Shard]]                                        =
+    ZIO
+      .service[Client.Service]
+      .flatMap(_.listShards(name).runCollect)
+      .filterOrElse(_.nonEmpty)(_ => getShards(name).delay(1.second))
+      .catchSome { case _: ResourceInUseException => getShards(name).delay(1.second) }
 
   def createStream(streamName: String, nrShards: Int): ZManaged[Console with AdminClient with Clock, Throwable, Unit] =
     createStreamUnmanaged(streamName, nrShards).toManaged(_ =>

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinatorTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinatorTest.scala
@@ -1,0 +1,170 @@
+package nl.vroste.zio.kinesis.client.zionative
+
+import nl.vroste.zio.kinesis.client.zionative.Consumer.InitialPosition
+import nl.vroste.zio.kinesis.client.zionative.LeaseRepository.Lease
+import nl.vroste.zio.kinesis.client.zionative.leasecoordinator.DefaultLeaseCoordinator
+import software.amazon.awssdk.services.kinesis.model.Shard
+import zio.test.Assertion._
+import zio.test._
+
+object LeaseCoordinatorTest extends DefaultRunnableSpec {
+
+  val shard1 = Shard.builder().shardId("001").build()
+  val shard2 = Shard.builder().shardId("002").build()
+  val shard3 = Shard.builder().shardId("003").parentShardId("001").adjacentParentShardId("002").build()
+
+  override def spec =
+    suite("DefaultLeaseCoordinator")(
+      suite("initialCheckpointForShard")(
+        test("for InitialPosition.Latest for shard without parents") {
+
+          val checkpoint = DefaultLeaseCoordinator.initialCheckpointForShard(shard1, InitialPosition.Latest, Map.empty)
+
+          assert(checkpoint)(equalTo(SpecialCheckpoint.Latest))
+        },
+        test("for InitialPosition.Latest for shard with parents without lease") {
+          val checkpoint = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, Map.empty)
+
+          assert(checkpoint)(equalTo(SpecialCheckpoint.Latest))
+        },
+        test("for InitialPosition.Latest for shard with parents with open leases") {
+          val leases     = Map(
+            "001" -> Lease(
+              key = "001",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Right(ExtendedSequenceNumber("1", 0))),
+              parentShardIds = Seq.empty
+            )
+          )
+          val checkpoint = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, leases)
+
+          assert(checkpoint)(equalTo(SpecialCheckpoint.TrimHorizon))
+        },
+        test("for InitialPosition.Latest for shard with parents with ended leases") {
+          val leases     = Map(
+            "001" -> Lease(
+              key = "001",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Left(SpecialCheckpoint.ShardEnd)),
+              parentShardIds = Seq.empty
+            )
+          )
+          val checkpoint = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, leases)
+
+          assert(checkpoint)(equalTo(SpecialCheckpoint.TrimHorizon))
+        }
+      ),
+      suite("shardsReadyToConsume")(
+        test("shards without parents and no leases ready to consume") {
+          val shards = Seq(shard1, shard2).map(s => s.shardId() -> s).toMap
+
+          val leases: Map[String, Lease] = Map.empty
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(equalTo(Set("001", "002")))
+        },
+        test("shards without parents and open leases ready to consume") {
+          val shards = Seq(shard1, shard2).map(s => s.shardId() -> s).toMap
+
+          val leases = Map(
+            "001" -> Lease(
+              key = "001",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Right(ExtendedSequenceNumber("1", 0))),
+              parentShardIds = Seq.empty
+            ),
+            "002" -> Lease(
+              key = "002",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Right(ExtendedSequenceNumber("1", 0))),
+              parentShardIds = Seq.empty
+            )
+          )
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(equalTo(Set("001", "002")))
+        },
+        test("shards without parents and ended leases not ready to consume") {
+          val shards = Seq(shard1, shard2).map(s => s.shardId() -> s).toMap
+
+          val leases = Map(
+            "001" -> Lease(
+              key = "001",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Left(SpecialCheckpoint.ShardEnd)),
+              parentShardIds = Seq.empty
+            ),
+            "002" -> Lease(
+              key = "002",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Left(SpecialCheckpoint.ShardEnd)),
+              parentShardIds = Seq.empty
+            )
+          )
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(equalTo(Set.empty[String]))
+        },
+        test("shards with open parents but no leases not ready to consume") {
+          val shards = Seq(shard1, shard2, shard3).map(s => s.shardId() -> s).toMap
+
+          val leases: Map[String, Lease] = Map.empty
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(not(contains("003")))
+        },
+        test("shards with expired parents ready to consume") {
+          val shards = Seq(shard3).map(s => s.shardId() -> s).toMap
+
+          val leases: Map[String, Lease] = Map.empty
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(contains("003"))
+        },
+        test("shards with open parents and open leases not ready to consume") {
+          val shards = Seq(shard1, shard2, shard3).map(s => s.shardId() -> s).toMap
+
+          val leases = Map(
+            "001" -> Lease(
+              key = "001",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Right(ExtendedSequenceNumber("1", 0))),
+              parentShardIds = Seq.empty
+            ),
+            "002" -> Lease(
+              key = "002",
+              owner = Some("worker1"),
+              counter = 1,
+              checkpoint = Some(Right(ExtendedSequenceNumber("1", 0))),
+              parentShardIds = Seq.empty
+            )
+          )
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(not(contains("003")))
+        },
+        test("shards with two parents of which one has expired not ready to consume") {
+          val shards = Seq(shard2, shard3).map(s => s.shardId() -> s).toMap
+
+          val leases: Map[String, Lease] = Map.empty
+
+          val readyToConsume = DefaultLeaseCoordinator.shardsReadyToConsume(shards, leases).keySet
+
+          assert(readyToConsume)(not(contains("003")))
+        }
+      )
+    )
+}

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinatorTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinatorTest.scala
@@ -28,7 +28,7 @@ object LeaseCoordinatorTest extends DefaultRunnableSpec {
           assert(checkpoint)(equalTo(SpecialCheckpoint.Latest))
         },
         test("for InitialPosition.Latest for shard with parents with open leases") {
-          val leases     = Map(
+          val leases: Map[String, Lease] = Map(
             "001" -> Lease(
               key = "001",
               owner = Some("worker1"),
@@ -37,12 +37,12 @@ object LeaseCoordinatorTest extends DefaultRunnableSpec {
               parentShardIds = Seq.empty
             )
           )
-          val checkpoint = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, leases)
+          val checkpoint                 = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, leases)
 
           assert(checkpoint)(equalTo(SpecialCheckpoint.TrimHorizon))
         },
         test("for InitialPosition.Latest for shard with parents with ended leases") {
-          val leases     = Map(
+          val leases: Map[String, Lease] = Map(
             "001" -> Lease(
               key = "001",
               owner = Some("worker1"),
@@ -51,7 +51,7 @@ object LeaseCoordinatorTest extends DefaultRunnableSpec {
               parentShardIds = Seq.empty
             )
           )
-          val checkpoint = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, leases)
+          val checkpoint                 = DefaultLeaseCoordinator.initialCheckpointForShard(shard3, InitialPosition.Latest, leases)
 
           assert(checkpoint)(equalTo(SpecialCheckpoint.TrimHorizon))
         }

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -786,9 +786,8 @@ object NativeConsumerTest extends DefaultRunnableSpec {
       checkpoints = leases.collect {
                       case l if l.checkpoint.isDefined =>
                         l.key -> (l.checkpoint.get match {
-                          case Left(SpecialCheckpoint.ShardEnd)    => SpecialCheckpoint.ShardEnd.stringValue
-                          case Left(SpecialCheckpoint.TrimHorizon) => SpecialCheckpoint.TrimHorizon.stringValue
-                          case Right(seqnr)                        => seqnr.sequenceNumber
+                          case Left(s @ _)  => s.stringValue
+                          case Right(seqnr) => seqnr.sequenceNumber
                         })
                     }.toMap
     } yield checkpoints

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -650,7 +650,9 @@ object NativeConsumerTest extends DefaultRunnableSpec {
 
   val loggingLayer = Slf4jLogger.make((_, logEntry) => logEntry, Some(getClass.getName))
 
-  val env = ((client.defaultAwsLayer.orDie >+>
+  val useAws = false
+
+  val env = (((if (useAws) client.defaultAwsLayer else LocalStackServices.localStackAwsLayer).orDie >+>
     (AdminClient.live ++ Client.live ++ DynamoDbLeaseRepository.live)).orDie ++
     zio.test.environment.testEnvironment ++
     Clock.live) >>>

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -685,7 +685,7 @@ object NativeConsumerTest extends DefaultRunnableSpec {
       table      <- ZIO.service[LeaseRepository.Service]
       leases     <- table.getLeases(applicationName).runCollect
       checkpoints = leases.collect {
-                      case l if l.checkpoint.isDefined => l.key -> l.checkpoint.get.sequenceNumber
+                      case l if l.checkpoint.isDefined => l.key -> l.checkpoint.get.toOption.get.sequenceNumber
                     }.toMap
     } yield checkpoints
 

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -678,24 +678,22 @@ object NativeConsumerTest extends DefaultRunnableSpec {
 
             for {
               producer    <- produceSampleRecords(streamName, nrRecords, chunkSize = 50, throttle = Some(1.second)).fork
-              client      <- ZIO.service[Client.Service]
               adminClient <- ZIO.service[AdminClient.Service]
 
-              //              events <- Ref.make[List[DiagnosticEvent]](List.empty)
-              stream         <-
+              stream  <-
                 consumer("worker1", e => UIO(println(e.toString))).runCollect.tapCause(e => UIO(println(e))).fork
-              _              <- ZIO.sleep(10.seconds)
-              _               = println("Resharding")
-              _              <- adminClient.updateShardCount(streamName, nrShards * 2)
-              _              <- ZIO.sleep(10.seconds)
-              finishedShards <- stream.join
-              shards         <- TestUtil.getShards(streamName)
-              _               = println(shards.mkString(", "))
-              stream2        <-
+              _       <- ZIO.sleep(10.seconds)
+              _        = println("Resharding")
+              _       <- adminClient.updateShardCount(streamName, nrShards * 2)
+              _       <- ZIO.sleep(10.seconds)
+              _       <- stream.join
+              shards  <- TestUtil.getShards(streamName)
+              _        = println(shards.mkString(", "))
+              stream2 <-
                 consumer("worker1", e => UIO(println(e.toString))).runCollect.tapCause(e => UIO(println(e))).fork
-              _              <- ZIO.sleep(30.seconds)
-              _              <- stream2.interrupt
-              _              <- producer.interrupt
+              _       <- ZIO.sleep(30.seconds)
+              _       <- stream2.interrupt
+              _       <- producer.interrupt
             } yield assertCompletes
         }
       } @@ TestAspect.ifEnvSet("ENABLE_AWS")

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -3,6 +3,8 @@ package nl.vroste.zio.kinesis.client.zionative
 import java.time.Instant
 import java.{ util => ju }
 
+import nl.vroste.zio.kinesis.client
+
 import scala.collection.compat._
 import nl.vroste.zio.kinesis.client.Client.ProducerRecord
 import nl.vroste.zio.kinesis.client.{ AdminClient, Client, LocalStackServices, Producer }
@@ -584,7 +586,62 @@ object NativeConsumerTest extends DefaultRunnableSpec {
               _             <- stream.interrupt
             } yield assertCompletes
         }
-      }
+      },
+      testM("must checkpoint when a shard ends") {
+        val nrRecords = 20000
+        val nrShards  = 3
+
+        withRandomStreamAndApplicationName(nrShards) {
+          (streamName, applicationName) =>
+            def consumer(workerId: String, emitDiagnostic: DiagnosticEvent => UIO[Unit]) =
+              Consumer
+                .shardedStream(
+                  streamName,
+                  applicationName,
+                  Serde.asciiString,
+                  workerIdentifier = workerId,
+                  leaseCoordinationSettings = LeaseCoordinationSettings(
+                    renewInterval = 30.seconds,
+                    refreshAndTakeInterval = 10.seconds,
+                    maxParallelLeaseAcquisitions = 1
+                  ),
+                  emitDiagnostic = emitDiagnostic
+                )
+                .mapM {
+                  case (shard @ _, shardStream, checkpointer) =>
+                    shardStream
+                      .tap(checkpointer.stage)
+                      .aggregateAsyncWithin(ZTransducer.collectAllN(200), Schedule.fixed(1.second))
+                      .mapError[Either[Throwable, ShardLeaseLost.type]](Left(_))
+                      .map(_.last)
+                      .tap(_ => checkpointer.checkpoint())
+                      .catchAll {
+                        case Right(_) =>
+                          ZStream.empty
+                        case Left(e)  => ZStream.fail(e)
+                      }
+                      .runDrain
+                      .as(shard)
+                }
+                .take(1)
+
+            for {
+              producer    <- produceSampleRecords(streamName, nrRecords, chunkSize = 50, throttle = Some(1.second)).fork
+              client      <- ZIO.service[Client.Service]
+              adminClient <- ZIO.service[AdminClient.Service]
+
+//              events <- Ref.make[List[DiagnosticEvent]](List.empty)
+              stream        <-
+                consumer("worker1", e => UIO(println(e.toString))).runCollect.tapCause(e => UIO(println(e))).fork
+              _             <- ZIO.sleep(20.seconds)
+              _              = println("Resharding")
+              _             <- adminClient.updateShardCount(streamName, 4)
+              finishedShard <- stream.join.map(_.head)
+              _             <- producer.interrupt
+              checkpoints   <- getCheckpoints(applicationName)
+            } yield assert(checkpoints(finishedShard))(equalTo("SHARD_END"))
+        }
+      } @@ TestAspect.ifEnvSet("MANUAL_TESTS")
     ).provideSomeLayerShared(env) @@
       TestAspect.timed @@
       TestAspect.sequential @@ // For CircleCI
@@ -593,7 +650,7 @@ object NativeConsumerTest extends DefaultRunnableSpec {
 
   val loggingLayer = Slf4jLogger.make((_, logEntry) => logEntry, Some(getClass.getName))
 
-  val env = ((LocalStackServices.localStackAwsLayer.orDie >+>
+  val env = ((client.defaultAwsLayer.orDie >+>
     (AdminClient.live ++ Client.live ++ DynamoDbLeaseRepository.live)).orDie ++
     zio.test.environment.testEnvironment ++
     Clock.live) >>>
@@ -663,24 +720,40 @@ object NativeConsumerTest extends DefaultRunnableSpec {
       leases <- table.getLeases(applicationName).runCollect
     } yield assert(leases)(forall(hasField("owner", _.owner, isNone)))
 
-  def getCheckpoints(applicationName: String) =
+  def getCheckpoints(
+    applicationName: String
+  ): ZIO[Clock with Has[LeaseRepository.Service], Throwable, Map[String, String]] =
     for {
       table      <- ZIO.service[LeaseRepository.Service]
       leases     <- table.getLeases(applicationName).runCollect
       checkpoints = leases.collect {
-                      case l if l.checkpoint.isDefined => l.key -> l.checkpoint.get.toOption.get.sequenceNumber
+                      case l if l.checkpoint.isDefined =>
+                        l.key -> (l.checkpoint.get match {
+                          case Left(SpecialCheckpoint.ShardEnd)    => SpecialCheckpoint.ShardEnd.stringValue
+                          case Left(SpecialCheckpoint.TrimHorizon) => SpecialCheckpoint.TrimHorizon.stringValue
+                          case Right(seqnr)                        => seqnr.sequenceNumber
+                        })
                     }.toMap
     } yield checkpoints
+
+  def deleteTable(applicationName: String) =
+    ZIO
+      .service[LeaseRepository.Service]
+      .flatMap(_.deleteTable(applicationName).unit)
 
   def withRandomStreamAndApplicationName[R, A](
     nrShards: Int
   )(
     f: (String, String) => ZIO[R, Throwable, A]
-  ): ZIO[Client with AdminClient with Clock with Console with R, Throwable, A] =
+  ): ZIO[Client with AdminClient with Clock with Logging with Console with Has[
+    LeaseRepository.Service
+  ] with R, Throwable, A] =
     ZIO.effectTotal((streamPrefix + "testStream", streamPrefix + "testApplication")).flatMap {
       case (streamName, applicationName) =>
         withStream(streamName, shards = nrShards) {
-          f(streamName, applicationName)
+          ZManaged.finalizer(deleteTable(applicationName).orDie).use_ {
+            f(streamName, applicationName)
+          }
         }
     }
 

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/PollingFetcherTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/PollingFetcherTest.scala
@@ -19,6 +19,7 @@ import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestClock
 import zio.duration._
+import zio.stream.ZStream
 
 import scala.jdk.CollectionConverters._
 
@@ -176,6 +177,10 @@ object PollingFetcherTest extends DefaultRunnableSpec {
                    fetcher
                      .shardRecordStream("shard1", ShardIteratorType.TrimHorizon)
                      .mapChunks(Chunk.single)
+                     .catchAll {
+                       case Left(e)  => ZStream.fail(e)
+                       case Right(_) => ZStream.empty
+                     }
                      .runCollect
                  }
         } yield assertCompletes)

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/PollingFetcherTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/PollingFetcherTest.scala
@@ -8,6 +8,7 @@ import nl.vroste.zio.kinesis.client.zionative.FetchMode.Polling
 import nl.vroste.zio.kinesis.client.zionative.fetcher.PollingFetcher
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model.{
+  ChildShard,
   GetRecordsResponse,
   ProvisionedThroughputExceededException,
   Record
@@ -279,8 +280,11 @@ object PollingFetcherTest extends DefaultRunnableSpec {
               val offset             = shardIterator.toInt
               val lastRecordOffset   = offset + limit
               val recordsInResponse  = records.slice(offset, offset + limit)
+              val shouldEnd          = lastRecordOffset >= records.size && endAfterRecords
               val nextShardIterator  =
-                if (lastRecordOffset >= records.size && endAfterRecords) null else lastRecordOffset.toString
+                if (shouldEnd) null else lastRecordOffset.toString
+              val childShards        =
+                if (shouldEnd) Seq(ChildShard.builder().shardId("shard-002").parentShards("001").build) else null
               val millisBehindLatest = if (lastRecordOffset >= records.size) 0 else records.size - lastRecordOffset
 
               //          println(s"GetRecords from ${shardIterator} (max ${limit}. Next iterator: ${nextShardIterator}")
@@ -290,6 +294,7 @@ object PollingFetcherTest extends DefaultRunnableSpec {
                 .records(recordsInResponse.asJava)
                 .millisBehindLatest(millisBehindLatest)
                 .nextShardIterator(nextShardIterator)
+                .childShards(childShards.asJava)
                 .build()
             }
         }

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategyTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategyTest.scala
@@ -26,7 +26,7 @@ object ShardAssignmentStrategyTest extends DefaultRunnableSpec {
                     counter    <- Gen.long(1, 1000)
                     sequenceNr <-
                       Gen.option(Gen.int(0, Int.MaxValue / 2).map(_.toString).map(ExtendedSequenceNumber(_, 0L)))
-                  } yield Lease(s"shard-${shard}", worker, counter, sequenceNr, Seq.empty)
+                  } yield Lease(s"shard-${shard}", worker, counter, sequenceNr.map(Right(_)), Seq.empty)
                 }
     } yield leases
 


### PR DESCRIPTION
Implements #184

* [x] Detect shard end
* [x] Checkpoint `SHARD_END`
* [x] Only begin processing a shard when the parent shards have finished processing (can we already claim the lease..?)
* [x] Do not process completed shards
* [x] Unit tests

Also:
* Optimize startup:
  * Try to load leases and only if it fails with ResourceNotFoundException create lease table
  * Fork a lot of initialisation of the DefaultLeaseCoordinator when its already ready to be used
  * Only fetch shards at startup when lease table did not exist (and there's more shards than retrieved from the stream description)
* Use `InitialPosition` instead of `ShardIteratorType` in `Consumer.shardedStream` because some of them were not valid initial positions
* New diagnostic events:
  * `ShardEnded`
  * `NewShardDetected`