### PR TITLE
Further Producer improvements

### DIFF
--- a/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -74,7 +74,7 @@ object ProducerTest extends DefaultRunnableSpec {
                        for {
                          _     <- putStrLn(s"Sending batch of size ${batch.size}!")
                          times <- ZIO.foreachPar(batch)(producer.produce(_).timed.map(_._1))
-                         _     <- timing.update(_.appended(times))
+                         _     <- timing.update(_ :+ times)
                          _     <-
                            putStrLn(s"Batch size ${batch.size}: avg = ${times.map(_.toMillis).sum / times.length} ms")
                        } yield ()

--- a/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -23,9 +23,6 @@ object ProducerTest extends DefaultRunnableSpec {
   val env = (LocalStackServices.localStackAwsLayer.orDie >>> (AdminClient.live ++ Client.live)).orDie >+>
     (loggingLayer ++ Clock.live)
 
-//  val env = (client.defaultAwsLayer >>> (AdminClient.live ++ Client.live)).orDie >+>
-//    (loggingLayer ++ Clock.live)
-
   def spec =
     suite("Producer")(
       testM("produce a single record immediately") {
@@ -87,7 +84,7 @@ object ProducerTest extends DefaultRunnableSpec {
               _       <- ZIO.foreach(results)(r => putStrLn(r.map(_.toMillis).mkString(" ")))
             } yield assertCompletes
         }
-      },
+      } @@ TestAspect.ignore,
       testM("produce records to Kinesis successfully and efficiently") {
         // This test demonstrates production of about 5000-6000 records per second on my Mid 2015 Macbook Pro
 
@@ -122,7 +119,7 @@ object ProducerTest extends DefaultRunnableSpec {
               _                <- putStrLn(s"Produced ${nrChunks * nrRecordsPerChunk * 1000.0 / time.toMillis}")
             } yield assertCompletes
         }.untraced
-      } @@ timeout(5.minute),
+      } @@ timeout(5.minute) @@ TestAspect.ignore,
       testM("fail when attempting to produce to a stream that does not exist") {
         val streamName = "zio-test-stream-not-existing"
 

--- a/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -9,26 +9,22 @@ import zio.clock.Clock
 import zio.console._
 import zio.duration._
 import zio.logging.slf4j.Slf4jLogger
-import zio.logging.{ LogContext, LogWriter, Logging }
+import zio.stream.ZStream
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio.{ Chunk, URIO, ZIO }
+import zio.{ Chunk, Ref, ZIO }
 
 object ProducerTest extends DefaultRunnableSpec {
   import TestUtil._
 
   val loggingLayer = Slf4jLogger.make((_, logEntry) => logEntry, Some(getClass.getName))
 
-  val myOwnLogger = Logging.make(new LogWriter[Any] {
-    override def writeLog(
-      context: LogContext,
-      line: => String
-    ): URIO[Any, Unit] = ???
-  })
-
   val env = (LocalStackServices.localStackAwsLayer.orDie >>> (AdminClient.live ++ Client.live)).orDie >+>
     (loggingLayer ++ Clock.live)
+
+//  val env = (client.defaultAwsLayer >>> (AdminClient.live ++ Client.live)).orDie >+>
+//    (loggingLayer ++ Clock.live)
 
   def spec =
     suite("Producer")(
@@ -37,9 +33,7 @@ object ProducerTest extends DefaultRunnableSpec {
         val streamName = "zio-test-stream-producer"
 
         (for {
-          _        <- putStrLn("Creating stream").toManaged_
           _        <- createStream(streamName, 1)
-          _        <- putStrLn("Creating producer").toManaged_
           producer <- Producer
                         .make(streamName, Serde.asciiString, ProducerSettings(bufferSize = 128))
         } yield producer).use { producer =>
@@ -54,13 +48,55 @@ object ProducerTest extends DefaultRunnableSpec {
           } yield assertCompletes
         }
       },
+      testM("support a ramp load") {
+        val streamName = "zio-test-stream-producer-ramp"
+
+        (for {
+          _        <- createStreamUnmanaged(streamName, 10).toManaged_
+          producer <- Producer
+                        .make(streamName, Serde.asciiString, ProducerSettings(bufferSize = 128))
+        } yield producer).use {
+          producer =>
+            val increment = 1
+            for {
+              batchSize <- Ref.make(1)
+              timing    <- Ref.make[Chunk[Chunk[Duration]]](Chunk.empty)
+
+              _       <- ZStream
+                     .tick(1.second)
+                     .take(200)
+                     .mapM(_ => batchSize.getAndUpdate(_ + 1))
+                     .map { batchSize =>
+                       Chunk.fromIterable(
+                         (1 to batchSize * increment).map(i =>
+                           ProducerRecord(s"key${i}" + UUID.randomUUID(), s"value${i}")
+                         )
+                       )
+                     }
+                     .mapM { batch =>
+                       for {
+                         _     <- putStrLn(s"Sending batch of size ${batch.size}!")
+                         times <- ZIO.foreachPar(batch)(producer.produce(_).timed.map(_._1))
+                         _     <- timing.update(_.appended(times))
+                         _     <-
+                           putStrLn(s"Batch size ${batch.size}: avg = ${times.map(_.toMillis).sum / times.length} ms")
+                       } yield ()
+                     }
+                     .runDrain
+              results <- timing.get
+              _       <- ZIO.foreach(results)(r => putStrLn(r.map(_.toMillis).mkString(" ")))
+            } yield assertCompletes
+        }
+      },
       testM("produce records to Kinesis successfully and efficiently") {
         // This test demonstrates production of about 5000-6000 records per second on my Mid 2015 Macbook Pro
 
-        val streamName = "zio-test-stream-" + UUID.randomUUID().toString
+        val streamName = "zio-test-stream-producer2"
 
         (for {
-          _        <- createStream(streamName, 10)
+          _        <- putStrLn("creating stream").toManaged_
+          _        <- createStreamUnmanaged(streamName, 50).toManaged_
+          _        <- putStrLn("creating producer").toManaged_
           producer <- Producer
                         .make(streamName, Serde.asciiString, ProducerSettings(bufferSize = 32768))
         } yield producer).use {
@@ -68,20 +104,22 @@ object ProducerTest extends DefaultRunnableSpec {
             for {
               _                <- ZIO.sleep(5.second)
               // Parallelism, but not infinitely (not sure if it matters)
-              nrChunks          = 50
-              nrRecordsPerChunk = 1000
+              nrChunks          = 100
+              nrRecordsPerChunk = 8000
               time             <- ZIO
-                        .collectAllParN_(20)((1 to nrChunks).map { i =>
+                        .collectAllParN_(3)((1 to nrChunks).map { i =>
                           for {
                             _      <- putStrLn(s"Starting chunk $i")
-                            records = (1 to nrRecordsPerChunk).map(j => ProducerRecord(s"key$i", s"message$i-$j"))
-                            _      <- (producer
-                                     .produceChunk(Chunk.fromIterable(records)) *> putStrLn(s"Chunk $i completed"))
+                            records = (1 to nrRecordsPerChunk).map(j =>
+                                        // Random UUID to get an even distribution over the shards
+                                        ProducerRecord(s"key$i" + UUID.randomUUID(), s"message$i-$j")
+                                      )
+                            _      <- (producer.produceChunk(Chunk.fromIterable(records)) *> putStrLn(s"Chunk $i completed"))
                           } yield ()
                         })
                         .timed
                         .map(_._1)
-              _                <- putStrLn(s"Produced ${nrChunks * nrRecordsPerChunk} in ${time.getSeconds}")
+              _                <- putStrLn(s"Produced ${nrChunks * nrRecordsPerChunk * 1000.0 / time.toMillis}")
             } yield assertCompletes
         }.untraced
       } @@ timeout(5.minute),


### PR DESCRIPTION
* use aggregateAsync to achieve desired batching behavior: only batch when there is backpressure from Kinesis calls
* no forking for failed records, instead take from the failed queue at regular intervals  
* use Promise.completeWith for (possibly) more efficient signaling 
* Some added testing