### PR TITLE
Refactor DefaultLeaseCoordinator

### DIFF
--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/LeaseCoordinator.scala
@@ -8,7 +8,9 @@ import zio.stream.ZStream
 import zio.{ Promise, UIO, ZIO }
 
 private[zionative] trait LeaseCoordinator {
-  def makeCheckpointer(shardId: String): ZIO[Clock with Logging, Throwable, Checkpointer with CheckpointerInternal]
+  def makeCheckpointer(
+    shardId: String
+  ): ZIO[Clock with Logging with Random, Throwable, Checkpointer with CheckpointerInternal]
 
   def getCheckpointForShard(shardId: String): UIO[Option[Either[SpecialCheckpoint, ExtendedSequenceNumber]]]
 

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/CheckpointerImpl.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/CheckpointerImpl.scala
@@ -1,0 +1,103 @@
+package nl.vroste.zio.kinesis.client.zionative.leasecoordinator
+import nl.vroste.zio.kinesis.client.Record
+import nl.vroste.zio.kinesis.client.zionative._
+import zio.clock.Clock
+import zio.logging.{ log, Logging }
+import zio.random.Random
+import zio._
+
+sealed trait CheckpointAction
+
+private[zionative] class CheckpointerImpl(
+  shardId: String,
+  env: Clock with Logging with Random,
+  maxSequenceNumber: Ref[Option[ExtendedSequenceNumber]],
+  lastCheckpoint: Ref[Option[ExtendedSequenceNumber]],
+  shardEnded: Ref[Boolean],
+  permit: Semaphore,
+  staged: Ref[Option[ExtendedSequenceNumber]],
+  updateCheckpoint: (
+    Either[SpecialCheckpoint, ExtendedSequenceNumber],
+    Boolean, // release
+    Boolean  // shard ended
+  ) => ZIO[Any, Either[Throwable, ShardLeaseLost.type], Unit],
+  releaseLease: ZIO[Any, Throwable, Unit]
+) extends Checkpointer
+    with CheckpointerInternal {
+  def checkpoint[R](
+    retrySchedule: Schedule[Clock with R, Throwable, Any]
+  ): ZIO[Clock with R, Either[Throwable, ShardLeaseLost.type], Unit] =
+    doCheckpoint(false)
+      .retry(retrySchedule +++ Schedule.stop) // Only retry Left[Throwable]
+
+  override def checkpointAndRelease: ZIO[Any, Either[Throwable, ShardLeaseLost.type], Unit] =
+    (maxSequenceNumber.get zip lastCheckpoint.get zip shardEnded.get).flatMap {
+      case ((maxSeqNr, lastCheckpoint), shardEnded) =>
+        log
+          .debug(
+            s"Checkpoint and release for shard ${shardId}, maxSeqNr=${maxSeqNr}, " +
+              s"lastCheckpoint=${lastCheckpoint}, shardEnded=${shardEnded}"
+          )
+          .provide(env)
+    } *> doCheckpoint(release = true)
+
+  private def doCheckpoint(release: Boolean): ZIO[Any, Either[Throwable, ShardLeaseLost.type], Unit] =
+    /*
+     * This uses a semaphore to ensure that two concurrent calls to `checkpoint` do not attempt
+     * to process the last staged record
+     *
+   * It is fine to stage new records for checkpointing though, those will be processed in the
+     * next call tho `checkpoint`. Staging is therefore not protected by a semaphore.
+     *
+   * If a new record is staged while the checkpoint operation is busy, the next call to checkpoint
+     * will use that record's sequence number.
+     *
+   * If checkpointing fails, the last staged sequence number is left unchanged, even it has already been
+     * updated.
+     *
+   * TODO make a test for that: staging while checkpointing should not lose the staged checkpoint.
+     */
+    permit.withPermit {
+      for {
+        lastStaged          <- staged.get
+        maxSequenceNumber   <- maxSequenceNumber.get
+        endOfShardSeen      <- shardEnded.get
+        lastCheckpointValue <- lastCheckpoint.get
+        _                   <- lastStaged match {
+               case Some(sequenceNr) =>
+                 val checkpoint: Either[SpecialCheckpoint, ExtendedSequenceNumber] =
+                   maxSequenceNumber
+                     .filter(_ == sequenceNr && endOfShardSeen)
+                     .map(_ => Left(SpecialCheckpoint.ShardEnd))
+                     .getOrElse(Right(sequenceNr))
+
+                 (updateCheckpoint(checkpoint, release, checkpoint.isLeft) *>
+                   lastCheckpoint.set(checkpoint.toOption) *>
+                   // only update when the staged record has not changed while checkpointing
+                   staged.updateSome { case Some(s) if s == sequenceNr => None }).uninterruptible
+               // Either the last checkpoint is the current max checkpoint (i.e. an empty poll at shard end)
+               // or we only get that empty poll (when having resumed the shard after the last sequence nr)
+               case None
+                   if release && endOfShardSeen && ((maxSequenceNumber.isEmpty && lastCheckpointValue.isEmpty) || lastCheckpointValue
+                     .exists(maxSequenceNumber.contains)) =>
+                 val checkpoint = Left(SpecialCheckpoint.ShardEnd)
+
+                 updateCheckpoint(checkpoint, release, true)
+
+               case None if release  =>
+                 releaseLease.mapError(Left(_))
+               case None             =>
+                 ZIO.unit
+             }
+      } yield ()
+    }
+
+  override def stage(r: Record[_]): zio.UIO[Unit] =
+    staged.set(Some(ExtendedSequenceNumber(r.sequenceNumber, r.subSequenceNumber.getOrElse(0L))))
+
+  override def setMaxSequenceNumber(lastSequenceNumber: ExtendedSequenceNumber): UIO[Unit] =
+    maxSequenceNumber.set(Some(lastSequenceNumber))
+
+  override def markEndOfShard(): UIO[Unit] =
+    shardEnded.set(true)
+}

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultCheckpointer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultCheckpointer.scala
@@ -61,7 +61,7 @@ private[zionative] class DefaultCheckpointer(
                      .map(_ => Left(SpecialCheckpoint.ShardEnd))
                      .getOrElse(Right(sequenceNr))
 
-                 (updateCheckpoint(checkpoint, release, checkpoint.isLeft) *>
+                 (updateCheckpoint(checkpoint, release) *>
                    state.update(_.copy(lastCheckpoint = checkpoint.toOption)) *>
                    // only update when the staged record has not changed while checkpointing
                    state.updateSome {
@@ -74,7 +74,7 @@ private[zionative] class DefaultCheckpointer(
                      .exists(maxSequenceNumber.contains)) =>
                  val checkpoint = Left(SpecialCheckpoint.ShardEnd)
 
-                 updateCheckpoint(checkpoint, release, true)
+                 updateCheckpoint(checkpoint, release)
 
                case None if release  =>
                  releaseLease.mapError(Left(_))
@@ -97,8 +97,7 @@ private[zionative] class DefaultCheckpointer(
 private[zionative] object DefaultCheckpointer {
   type UpdateCheckpoint = (
     Either[SpecialCheckpoint, ExtendedSequenceNumber],
-    Boolean, // release
-    Boolean  // shard ended
+    Boolean // release
   ) => ZIO[Any, Either[Throwable, ShardLeaseLost.type], Unit]
 
   case class State(

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -343,86 +343,18 @@ private class DefaultLeaseCoordinator(
       shardEnded        <- Ref.make(false)
       permit            <- Semaphore.make(1)
       env               <- ZIO.environment[Logging with Clock with Random]
-    } yield new Checkpointer with CheckpointerInternal {
-      def checkpoint[R](
-        retrySchedule: Schedule[Clock with R, Throwable, Any]
-      ): ZIO[Clock with R, Either[Throwable, ShardLeaseLost.type], Unit] =
-        doCheckpoint(false)
-          .retry(retrySchedule +++ Schedule.stop) // Only retry Left[Throwable]
-
-      override def checkpointAndRelease: ZIO[Any, Either[Throwable, ShardLeaseLost.type], Unit] =
-        (maxSequenceNumber.get zip lastCheckpoint.get zip shardEnded.get).flatMap {
-          case ((maxSeqNr, lastCheckpoint), shardEnded) =>
-            log
-              .debug(
-                s"Checkpoint and release for shard ${shardId}, maxSeqNr=${maxSeqNr}, " +
-                  s"lastCheckpoint=${lastCheckpoint}, shardEnded=${shardEnded}"
-              )
-              .provide(env)
-        } *> doCheckpoint(release = true)
-
-      private def doCheckpoint(release: Boolean): ZIO[Any, Either[Throwable, ShardLeaseLost.type], Unit] =
-        /*
-         * This uses a semaphore to ensure that two concurrent calls to `checkpoint` do not attempt
-         * to process the last staged record
-         *
-         * It is fine to stage new records for checkpointing though, those will be processed in the
-         * next call tho `checkpoint`. Staging is therefore not protected by a semaphore.
-         *
-         * If a new record is staged while the checkpoint operation is busy, the next call to checkpoint
-         * will use that record's sequence number.
-         *
-         * If checkpointing fails, the last staged sequence number is left unchanged, even it has already been
-         * updated.
-         *
-         * TODO make a test for that: staging while checkpointing should not lose the staged checkpoint.
-         */
-        permit.withPermit {
-          for {
-            lastStaged          <- staged.get
-            maxSequenceNumber   <- maxSequenceNumber.get
-            endOfShardSeen      <- shardEnded.get
-            lastCheckpointValue <- lastCheckpoint.get
-            _                   <- lastStaged match {
-                   case Some(sequenceNr) =>
-                     val checkpoint: Either[SpecialCheckpoint, ExtendedSequenceNumber] =
-                       maxSequenceNumber
-                         .filter(_ == sequenceNr && endOfShardSeen)
-                         .map(_ => Left(SpecialCheckpoint.ShardEnd))
-                         .getOrElse(Right(sequenceNr))
-
-                     (serialExecutionByShard(shardId)(
-                       updateCheckpoint(shardId, checkpoint, release, shardEnded = checkpoint.isLeft).provide(env)
-                     ) *>
-                       lastCheckpoint.set(checkpoint.toOption) *>
-                       // only update when the staged record has not changed while checkpointing
-                       staged.updateSome { case Some(s) if s == sequenceNr => None }).uninterruptible
-                   // Either the last checkpoint is the current max checkpoint (i.e. an empty poll at shard end)
-                   // or we only get that empty poll (when having resumed the shard after the last sequence nr)
-                   case None
-                       if release && endOfShardSeen && ((maxSequenceNumber.isEmpty && lastCheckpointValue.isEmpty) || lastCheckpointValue
-                         .exists(maxSequenceNumber.contains)) =>
-                     val checkpoint = Left(SpecialCheckpoint.ShardEnd)
-                     serialExecutionByShard(shardId)(
-                       updateCheckpoint(shardId, checkpoint, release, shardEnded = true).provide(env)
-                     )
-                   case None if release  =>
-                     serialExecutionByShard(shardId)(releaseLease(shardId).provide(env)).mapError(Left(_))
-                   case None             =>
-                     ZIO.unit
-                 }
-          } yield ()
-        }
-
-      override def stage(r: Record[_]): zio.UIO[Unit] =
-        staged.set(Some(ExtendedSequenceNumber(r.sequenceNumber, r.subSequenceNumber.getOrElse(0L))))
-
-      override def setMaxSequenceNumber(lastSequenceNumber: ExtendedSequenceNumber): UIO[Unit] =
-        maxSequenceNumber.set(Some(lastSequenceNumber))
-
-      override def markEndOfShard(): UIO[Unit] =
-        shardEnded.set(true)
-    }
+    } yield new CheckpointerImpl(
+      shardId,
+      env,
+      maxSequenceNumber,
+      lastCheckpoint,
+      shardEnded,
+      permit,
+      staged,
+      (checkpoint, release, shardEnded) =>
+        serialExecutionByShard(shardId)(updateCheckpoint(shardId, checkpoint, release, shardEnded).provide(env)),
+      releaseLease(shardId).provide(env)
+    )
 
   private def updateCheckpoint(
     shard: String,

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -346,7 +346,7 @@ private class DefaultLeaseCoordinator(
       permit,
       (checkpoint, release) =>
         serialExecutionByShard(shardId)(updateCheckpoint(shardId, checkpoint, release).provide(env)),
-      releaseLease(shardId).provide(env)
+      serialExecutionByShard(shardId)(releaseLease(shardId).provide(env))
     )
 
   private def updateCheckpoint(

--- a/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/SerialExecution.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/SerialExecution.scala
@@ -1,0 +1,38 @@
+package nl.vroste.zio.kinesis.client.zionative.leasecoordinator
+import zio.stream.ZStream
+import zio.{ Promise, Queue, UIO, UManaged, ZIO }
+
+/**
+ * Ensures that effects are run serially per key
+ *
+ * @tparam K Type of key
+ */
+trait SerialExecution[K] {
+  def apply[R, E, A](key: K)(f: ZIO[R, E, A]): ZIO[R, E, A]
+}
+
+object SerialExecution {
+  def keyed[K](queueSize: Int = 128): UManaged[SerialExecution[K]] =
+    for {
+      queue <- Queue
+                 .bounded[(K, UIO[Unit])](queueSize)
+                 .toManaged_
+      _     <- ZStream
+             .fromQueue(queue)
+             .groupByKey(_._1) {
+               case (key @ _, actions) =>
+                 actions.mapM { case (_, action) => action }
+             }
+             .runDrain
+             .forkManaged
+    } yield new SerialExecution[K] {
+      override def apply[R, E, A](key: K)(f: ZIO[R, E, A]): ZIO[R, E, A] =
+        for {
+          p      <- Promise.make[E, A]
+          env    <- ZIO.environment[R]
+          action  = f.provide(env).foldM(p.fail, p.succeed).unit
+          _      <- queue.offer((key, action))
+          result <- p.await
+        } yield result
+    }
+}

--- a/src/test/scala/nl/vroste/zio/kinesis/client/zionative/DefaultCheckpointerTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/zionative/DefaultCheckpointerTest.scala
@@ -1,0 +1,84 @@
+package nl.vroste.zio.kinesis.client.zionative
+import java.time.Instant
+
+import nl.vroste.zio.kinesis.client.Record
+import nl.vroste.zio.kinesis.client.zionative.leasecoordinator.DefaultCheckpointer
+import nl.vroste.zio.kinesis.client.zionative.leasecoordinator.DefaultCheckpointer.UpdateCheckpoint
+import software.amazon.awssdk.services.kinesis.model.EncryptionType
+import zio.logging.Logging
+import zio.{ Promise, Ref, Semaphore, Task, ZIO }
+import zio.test._
+import zio.test.Assertion._
+
+object DefaultCheckpointerTest extends DefaultRunnableSpec {
+  val record1 = Record("shard1", "0", Instant.now, "bla", "bla", EncryptionType.NONE, None, None, false)
+  val record2 = Record("shard1", "1", Instant.now, "bla", "bla", EncryptionType.NONE, None, None, false)
+
+  override def spec =
+    suite("DefaultCheckpointer")(
+      testM("checkpoints the last staged record") {
+        for {
+          checkpoints  <- Ref.make(List.empty[Either[SpecialCheckpoint, ExtendedSequenceNumber]])
+          checkpointer <- {
+            val updateCheckpoint: UpdateCheckpoint = {
+              case (seqNr, _, _) => checkpoints.update(_ :+ seqNr)
+            }
+            makeCheckpointer(updateCheckpoint)
+          }
+          _            <- checkpointer.stage(record1)
+          _            <- checkpointer.stage(record2)
+          _            <- checkpointer.checkpoint()
+          values       <- checkpoints.get
+        } yield assert(values.map(_.toOption.get.sequenceNumber))(equalTo(List("1")))
+      },
+      testM("does not checkpoint the same staged checkpoint twice") {
+        for {
+          checkpoints  <- Ref.make(List.empty[Either[SpecialCheckpoint, ExtendedSequenceNumber]])
+          checkpointer <- {
+            val updateCheckpoint: UpdateCheckpoint = {
+              case (seqNr, _, _) => checkpoints.update(_ :+ seqNr)
+            }
+            makeCheckpointer(updateCheckpoint)
+          }
+          _            <- checkpointer.stage(record1)
+          _            <- checkpointer.checkpoint()
+          _            <- checkpointer.checkpoint()
+          values       <- checkpoints.get
+        } yield assert(values.map(_.toOption.get.sequenceNumber))(equalTo(List("0")))
+      },
+      testM("preserves the last staged checkpoint while checkpointing") {
+        for {
+          checkpoints  <- Ref.make(List.empty[Either[SpecialCheckpoint, ExtendedSequenceNumber]])
+          latch1       <- Promise.make[Nothing, Unit]
+          latch2       <- Promise.make[Nothing, Unit]
+          checkpointer <- {
+            val updateCheckpoint: UpdateCheckpoint = {
+              case (seqNr, _, _) => latch1.succeed(()) *> latch2.await *> checkpoints.update(_ :+ seqNr)
+            }
+            makeCheckpointer(updateCheckpoint)
+          }
+          _            <- checkpointer.stage(record1)
+          _            <- checkpointer.checkpoint() <&
+                 (latch1.await *> checkpointer.stage(record2) *> latch2.succeed(()))
+          _            <- checkpointer.checkpoint()
+          values       <- checkpoints.get
+        } yield assert(values.map(_.toOption.get.sequenceNumber))(equalTo(List("0", "1")))
+      }
+    ).provideCustomLayerShared(Logging.ignore)
+
+  /*
+  TODO:
+  - retries according to schedule
+  - releases
+  - not beyond max seq nr (also implement this)
+  - handles shard end correctly (TBD)
+   */
+
+  private def makeCheckpointer(updateCheckpoint: UpdateCheckpoint): ZIO[Logging, Nothing, DefaultCheckpointer] =
+    for {
+      state       <- Ref.make(DefaultCheckpointer.State.empty)
+      permit      <- Semaphore.make(1)
+      env         <- ZIO.environment[Logging]
+      checkpointer = new DefaultCheckpointer("shard1", env, state, permit, updateCheckpoint, Task.unit)
+    } yield checkpointer
+}


### PR DESCRIPTION
* Remove need for command objects with `SerialExecution`
* Extract checkpointer to `DefaultCheckpointer`
* Move private methods closer to call site(s)
* Tests for `DefaultCheckpointer`