### PR TITLE
Make DynamicConsumer and Checkpointer polymorphic in T

### DIFF
--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumer.scala
@@ -72,6 +72,9 @@ object DynamicConsumer {
       }
     }
 
+  /**
+   * @tparam T Type of Record data value
+   */
   trait Service[T] {
 
     /**
@@ -226,6 +229,7 @@ object DynamicConsumer {
    * Staging area for checkpoints
    *
    * Guarantees that the last staged record is checkpointed upon stream shutdown / interruption
+   * @tparam T Type of Record data value
    */
   trait Checkpointer[T] {
 

--- a/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/DynamicConsumerLive.scala
@@ -20,13 +20,13 @@ import zio.stream.ZStream
 
 import scala.jdk.CollectionConverters._
 
-private[client] class DynamicConsumerLive(
+private[client] class DynamicConsumerLive[T](
   logger: Logger[String],
   kinesisAsyncClient: KinesisAsyncClient,
   cloudWatchAsyncClient: CloudWatchAsyncClient,
   dynamoDbAsyncClient: DynamoDbAsyncClient
-) extends DynamicConsumer.Service {
-  override def shardedStream[R, T](
+) extends DynamicConsumer.Service[T] {
+  override def shardedStream[R](
     streamName: String,
     applicationName: String,
     deserializer: Deserializer[R, T],

--- a/src/main/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFake.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFake.scala
@@ -48,17 +48,15 @@ private[client] class DynamicConsumerFake[T](
     shards.flatMap {
       case (shardName, stream) =>
         ZStream.fromEffect {
-          ZIO.environment[R with Blocking].flatMap { env => //TODO: remove env
-            CheckpointerFake.make(refCheckpointedList).map { checkpointer =>
-              (
-                shardName,
-                stream.zipWithIndex.mapM {
-                  case (data, i) =>
-                    record(shardName, data, i)
-                },
-                checkpointer
-              )
-            }
+          CheckpointerFake.make(refCheckpointedList).map { checkpointer =>
+            (
+              shardName,
+              stream.zipWithIndex.mapM {
+                case (data, i) =>
+                  record(shardName, data, i)
+              },
+              checkpointer
+            )
           }
         }
     }

--- a/src/main/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFake.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFake.scala
@@ -12,12 +12,12 @@ import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.stream.ZStream
 
-private[client] class DynamicConsumerFake(
+private[client] class DynamicConsumerFake[T](
   shards: ZStream[Any, Throwable, (String, ZStream[Any, Throwable, ByteBuffer])],
   refCheckpointedList: Ref[Seq[_]],
   clock: Clock.Service
-) extends DynamicConsumer.Service {
-  override def shardedStream[R, T](
+) extends DynamicConsumer.Service[T] {
+  override def shardedStream[R](
     streamName: String,
     applicationName: String,
     deserializer: Deserializer[R, T],

--- a/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
+++ b/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
@@ -9,10 +9,10 @@ import zio.{ Has, ZIO, ZLayer, ZManaged }
 
 package object client {
 
-  type AdminClient     = Has[AdminClient.Service]
-  type Client          = Has[Client.Service]
-  type DynamicConsumer = Has[DynamicConsumer.Service]
-  type HttpClient      = Has[HttpClient.Service]
+  type AdminClient        = Has[AdminClient.Service]
+  type Client             = Has[Client.Service]
+  type DynamicConsumer[T] = Has[DynamicConsumer.Service[T]]
+  type HttpClient         = Has[HttpClient.Service]
 
   def kinesisAsyncClientLayer(
     build: KinesisAsyncClientBuilder => KinesisAsyncClient = _.build()

--- a/src/test/scala/nl/vroste/zio/kinesis/client/ConsumeWithTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ConsumeWithTest.scala
@@ -28,9 +28,9 @@ object ConsumeWithTest extends DefaultRunnableSpec {
   private val env
     : ZLayer[Any, Throwable, Console with Clock with Logging with Blocking with Has[CloudWatchAsyncClient] with Has[
       KinesisAsyncClient
-    ] with Has[DynamoDbAsyncClient] with Has[DynamicConsumer.Service] with Client with AdminClient] =
+    ] with Has[DynamoDbAsyncClient] with Has[DynamicConsumer.Service[String]] with Client with AdminClient] =
     (Console.live ++ Clock.live ++ Blocking.live) >+> loggingLayer >+> LocalStackServices
-      .localStackAwsLayer() >+> (DynamicConsumer.live ++ Client.live ++ AdminClient.live)
+      .localStackAwsLayer() >+> (DynamicConsumer.live[String] ++ Client.live ++ AdminClient.live)
 
   def testConsume1 =
     testM("consumeWith should consume records produced on all shards") {

--- a/src/test/scala/nl/vroste/zio/kinesis/client/ExampleApp.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/ExampleApp.scala
@@ -191,7 +191,7 @@ object ExampleApp extends zio.App {
 
   val awsEnv: ZLayer[Clock, Nothing, Clock with Has[KinesisAsyncClient] with Has[CloudWatchAsyncClient] with Has[
     DynamoDbAsyncClient
-  ] with Logging with Client with AdminClient with Has[DynamicConsumer.Service] with LeaseRepository with Has[
+  ] with Logging with Client with AdminClient with Has[DynamicConsumer.Service[String]] with LeaseRepository with Has[
     CloudWatchMetricsPublisherConfig
   ]] = {
     val httpClient    = HttpClient.make(
@@ -207,7 +207,7 @@ object ExampleApp extends zio.App {
     val adminClient = AdminClient.live.orDie
 
     val leaseRepo       = DynamoDbLeaseRepository.live
-    val dynamicConsumer = DynamicConsumer.live
+    val dynamicConsumer = DynamicConsumer.live[String]
     val logging         = loggingLayer
 
     val metricsPublisherConfig = ZLayer.succeed(CloudWatchMetricsPublisherConfig())

--- a/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerBasicUsageExample.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerBasicUsageExample.scala
@@ -32,6 +32,6 @@ object DynamicConsumerBasicUsageExample extends zio.App {
             .via(checkpointer.checkpointBatched[Blocking with Console](nr = 1000, interval = 5.second))
       }
       .runDrain
-      .provideCustomLayer(loggingLayer ++ defaultAwsLayer >>> DynamicConsumer.live)
+      .provideCustomLayer(loggingLayer ++ defaultAwsLayer >>> DynamicConsumer.live[String])
       .exitCode
 }

--- a/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerConsumeWithExample.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerConsumeWithExample.scala
@@ -26,6 +26,6 @@ object DynamicConsumerConsumeWithExample extends zio.App {
         checkpointBatchSize = 1000L,
         checkpointDuration = 5.minutes
       )(record => putStrLn(s"Processing record $record"))
-      .provideCustomLayer(loggingLayer ++ defaultAwsLayer >>> DynamicConsumer.live ++ loggingLayer)
+      .provideCustomLayer(loggingLayer ++ defaultAwsLayer >>> DynamicConsumer.live[String] ++ loggingLayer)
       .exitCode
 }

--- a/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerFakeExample.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerFakeExample.scala
@@ -1,42 +1,40 @@
-//package nl.vroste.zio.kinesis.client.examples
-//
-//import java.nio.ByteBuffer
-//
-//import nl.vroste.zio.kinesis.client.DynamicConsumer
-//import nl.vroste.zio.kinesis.client.fake.DynamicConsumerFake
-//import nl.vroste.zio.kinesis.client.serde.Serde
-//import zio._
-//import zio.clock.Clock
-//import zio.console.{ putStrLn, Console }
-//import zio.duration._
-//import zio.logging.Logging
-//import zio.stream.ZStream
-//
-///**
-// * Basic usage example for `DynamicConsumerFake`
-// */
-//object DynamicConsumerFakeExample extends zio.App {
-//  val loggingLayer: ZLayer[Any, Nothing, Logging] =
-//    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
-//
-//  private val shards: ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])] =
-//    DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
-//
-//  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
-//    for {
-//      refCheckpointedList <- Ref.make[Seq[_]](Seq.empty[String])
-//      exitCode            <- DynamicConsumer
-//                    .consumeWith(
-//                      streamName = "my-stream",
-//                      applicationName = "my-application",
-//                      deserializer = Serde.asciiString,
-//                      workerIdentifier = "worker1",
-//                      checkpointBatchSize = 1000L,
-//                      checkpointDuration = 5.minutes
-//                    )(record => putStrLn(s"Processing record $record"))
-//                    .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
-//                    .exitCode
-//      _                   <- putStrLn(s"refCheckpointedList=$refCheckpointedList")
-//    } yield exitCode
-//
-//}
+package nl.vroste.zio.kinesis.client.examples
+
+import nl.vroste.zio.kinesis.client.DynamicConsumer
+import nl.vroste.zio.kinesis.client.fake.DynamicConsumerFake
+import nl.vroste.zio.kinesis.client.serde.Serde
+import zio._
+import zio.clock.Clock
+import zio.console.{ putStrLn, Console }
+import zio.duration._
+import zio.logging.Logging
+import zio.stream.ZStream
+
+/**
+ * Basic usage example for `DynamicConsumerFake`
+ */
+object DynamicConsumerFakeExample extends zio.App {
+  val loggingLayer: ZLayer[Any, Nothing, Logging] =
+    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
+
+  private val shards: ZStream[Any, Nothing, (String, ZStream[Any, Throwable, String])] =
+    DynamicConsumerFake.shardsFromStreams(ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
+
+  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
+    for {
+      refCheckpointedList <- Ref.make(Seq.empty[String])
+      exitCode            <- DynamicConsumer
+                    .consumeWith(
+                      streamName = "my-stream",
+                      applicationName = "my-application",
+                      deserializer = Serde.asciiString,
+                      workerIdentifier = "worker1",
+                      checkpointBatchSize = 1000L,
+                      checkpointDuration = 5.minutes
+                    )(record => putStrLn(s"Processing record $record"))
+                    .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
+                    .exitCode
+      _                   <- putStrLn(s"refCheckpointedList=$refCheckpointedList")
+    } yield exitCode
+
+}

--- a/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerFakeExample.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/examples/DynamicConsumerFakeExample.scala
@@ -1,42 +1,42 @@
-package nl.vroste.zio.kinesis.client.examples
-
-import java.nio.ByteBuffer
-
-import nl.vroste.zio.kinesis.client.DynamicConsumer
-import nl.vroste.zio.kinesis.client.fake.DynamicConsumerFake
-import nl.vroste.zio.kinesis.client.serde.Serde
-import zio._
-import zio.clock.Clock
-import zio.console.{ putStrLn, Console }
-import zio.duration._
-import zio.logging.Logging
-import zio.stream.ZStream
-
-/**
- * Basic usage example for `DynamicConsumerFake`
- */
-object DynamicConsumerFakeExample extends zio.App {
-  val loggingLayer: ZLayer[Any, Nothing, Logging] =
-    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
-
-  private val shards: ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])] =
-    DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
-
-  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
-    for {
-      refCheckpointedList <- Ref.make[Seq[_]](Seq.empty[String])
-      exitCode            <- DynamicConsumer
-                    .consumeWith(
-                      streamName = "my-stream",
-                      applicationName = "my-application",
-                      deserializer = Serde.asciiString,
-                      workerIdentifier = "worker1",
-                      checkpointBatchSize = 1000L,
-                      checkpointDuration = 5.minutes
-                    )(record => putStrLn(s"Processing record $record"))
-                    .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
-                    .exitCode
-      _                   <- putStrLn(s"refCheckpointedList=$refCheckpointedList")
-    } yield exitCode
-
-}
+//package nl.vroste.zio.kinesis.client.examples
+//
+//import java.nio.ByteBuffer
+//
+//import nl.vroste.zio.kinesis.client.DynamicConsumer
+//import nl.vroste.zio.kinesis.client.fake.DynamicConsumerFake
+//import nl.vroste.zio.kinesis.client.serde.Serde
+//import zio._
+//import zio.clock.Clock
+//import zio.console.{ putStrLn, Console }
+//import zio.duration._
+//import zio.logging.Logging
+//import zio.stream.ZStream
+//
+///**
+// * Basic usage example for `DynamicConsumerFake`
+// */
+//object DynamicConsumerFakeExample extends zio.App {
+//  val loggingLayer: ZLayer[Any, Nothing, Logging] =
+//    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
+//
+//  private val shards: ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])] =
+//    DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
+//
+//  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
+//    for {
+//      refCheckpointedList <- Ref.make[Seq[_]](Seq.empty[String])
+//      exitCode            <- DynamicConsumer
+//                    .consumeWith(
+//                      streamName = "my-stream",
+//                      applicationName = "my-application",
+//                      deserializer = Serde.asciiString,
+//                      workerIdentifier = "worker1",
+//                      checkpointBatchSize = 1000L,
+//                      checkpointDuration = 5.minutes
+//                    )(record => putStrLn(s"Processing record $record"))
+//                    .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
+//                    .exitCode
+//      _                   <- putStrLn(s"refCheckpointedList=$refCheckpointedList")
+//    } yield exitCode
+//
+//}

--- a/src/test/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFakeTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFakeTest.scala
@@ -1,129 +1,129 @@
-package nl.vroste.zio.kinesis.client.fake
-
-import java.nio.ByteBuffer
-import java.time.OffsetDateTime
-
-import nl.vroste.zio.kinesis.client.serde.Serde
-import nl.vroste.zio.kinesis.client.{ DynamicConsumer, Record }
-import software.amazon.awssdk.services.kinesis.model.EncryptionType
-import zio.clock.Clock
-import zio.console.Console
-import zio.duration._
-import zio.logging.Logging
-import zio.stream.ZStream
-import zio.test._
-import zio.{ Queue, Ref, ZLayer }
-
-object DynamicConsumerFakeTest extends DefaultRunnableSpec {
-  private type Shard = ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])]
-
-  private val now = OffsetDateTime.parse("1970-01-01T00:00:00Z")
-
-  private val loggingLayer: ZLayer[Any, Nothing, Logging] =
-    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
-
-  private val shardsFromIterables: Shard =
-    DynamicConsumerFake.shardsFromIterables(Serde.asciiString, List("msg1", "msg2"), List("msg3", "msg4"))
-  private val shardsFromStreams: Shard   =
-    DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
-
-  private val expectedRecords = {
-    def recordsForShard(shardName: String, xs: String*) =
-      xs.zipWithIndex.map {
-        case (s, i) =>
-          record(i.toLong, shardName, s)
-      }
-    recordsForShard("shard0", "msg1", "msg2") ++ recordsForShard("shard1", "msg3", "msg4")
-  }
-
-  private def record(sequenceNumber: Long, shardName: String, data: String) =
-    Record[String](
-      sequenceNumber = s"$sequenceNumber",
-      approximateArrivalTimestamp = now.toInstant,
-      data = data,
-      partitionKey = s"${shardName}_$sequenceNumber",
-      encryptionType = EncryptionType.NONE,
-      subSequenceNumber = None,
-      explicitHashKey = None,
-      aggregated = false,
-      shardId = shardName
-    )
-
-  def programCheckpointed(shards: Shard) =
-    for {
-      q                   <- Queue.unbounded[Record[String]]
-      refCheckpointedList <- Ref.make[Seq[_]](Seq.empty[String])
-      _                   <- DynamicConsumer
-             .consumeWith(
-               streamName = "my-stream",
-               applicationName = "my-application",
-               deserializer = Serde.asciiString,
-               workerIdentifier = "worker1",
-               checkpointBatchSize = 1000L,
-               checkpointDuration = 5.minutes
-             )(record => q.offer(record).unit)
-             .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
-             .exitCode
-      checkpointedList    <- refCheckpointedList.get
-      xs                  <- q.takeAll
-    } yield (checkpointedList, xs)
-
-  def program(shards: Shard) =
-    for {
-      q  <- Queue.unbounded[Record[String]]
-      _  <- DynamicConsumer
-             .consumeWith(
-               streamName = "my-stream",
-               applicationName = "my-application",
-               deserializer = Serde.asciiString,
-               workerIdentifier = "worker1",
-               checkpointBatchSize = 1000L,
-               checkpointDuration = 5.minutes
-             )(record => q.offer(record).unit)
-             .provideCustomLayer(DynamicConsumer.fake(shards) ++ loggingLayer)
-             .exitCode
-      xs <- q.takeAll
-    } yield xs
-
-  override def spec =
-    suite("DynamicConsumerFake should")(
-      suite("when checkpointed")(
-        testM("read from iterables when using shardsFromIterables") {
-          for {
-            t <- programCheckpointed(shardsFromIterables)
-          } yield assert(t._1)(
-            Assertion.hasSameElementsDistinct(
-              List(
-                record(sequenceNumber = 1, shardName = "shard0", data = "msg2"),
-                record(sequenceNumber = 1, shardName = "shard1", data = "msg4")
-              )
-            )
-          ) && assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
-        },
-        testM("read from streams when using shardsFromStreams") {
-          for {
-            t <- programCheckpointed(shardsFromStreams)
-          } yield assert(t._1)(
-            Assertion.hasSameElementsDistinct(
-              List(
-                record(sequenceNumber = 1, shardName = "shard0", data = "msg2"),
-                record(sequenceNumber = 1, shardName = "shard1", data = "msg4")
-              )
-            )
-          ) && assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
-        }
-      ),
-      suite("when not checkpointed")(
-        testM("read from iterables when using shardsFromIterables") {
-          for {
-            xs <- program(shardsFromIterables)
-          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
-        },
-        testM("read from streams when using shardsFromStreams") {
-          for {
-            xs <- program(shardsFromStreams)
-          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
-        }
-      )
-    )
-}
+//package nl.vroste.zio.kinesis.client.fake
+//
+//import java.nio.ByteBuffer
+//import java.time.OffsetDateTime
+//
+//import nl.vroste.zio.kinesis.client.serde.Serde
+//import nl.vroste.zio.kinesis.client.{ DynamicConsumer, Record }
+//import software.amazon.awssdk.services.kinesis.model.EncryptionType
+//import zio.clock.Clock
+//import zio.console.Console
+//import zio.duration._
+//import zio.logging.Logging
+//import zio.stream.ZStream
+//import zio.test._
+//import zio.{ Queue, Ref, ZLayer }
+//
+//object DynamicConsumerFakeTest extends DefaultRunnableSpec {
+//  private type Shard = ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])]
+//
+//  private val now = OffsetDateTime.parse("1970-01-01T00:00:00Z")
+//
+//  private val loggingLayer: ZLayer[Any, Nothing, Logging] =
+//    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
+//
+//  private val shardsFromIterables: Shard =
+//    DynamicConsumerFake.shardsFromIterables(Serde.asciiString, List("msg1", "msg2"), List("msg3", "msg4"))
+//  private val shardsFromStreams: Shard   =
+//    DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
+//
+//  private val expectedRecords = {
+//    def recordsForShard(shardName: String, xs: String*) =
+//      xs.zipWithIndex.map {
+//        case (s, i) =>
+//          record(i.toLong, shardName, s)
+//      }
+//    recordsForShard("shard0", "msg1", "msg2") ++ recordsForShard("shard1", "msg3", "msg4")
+//  }
+//
+//  private def record(sequenceNumber: Long, shardName: String, data: String) =
+//    Record[String](
+//      sequenceNumber = s"$sequenceNumber",
+//      approximateArrivalTimestamp = now.toInstant,
+//      data = data,
+//      partitionKey = s"${shardName}_$sequenceNumber",
+//      encryptionType = EncryptionType.NONE,
+//      subSequenceNumber = None,
+//      explicitHashKey = None,
+//      aggregated = false,
+//      shardId = shardName
+//    )
+//
+//  def programCheckpointed(shards: Shard) =
+//    for {
+//      q                   <- Queue.unbounded[Record[String]]
+//      refCheckpointedList <- Ref.make[Seq[_]](Seq.empty[String])
+//      _                   <- DynamicConsumer
+//             .consumeWith(
+//               streamName = "my-stream",
+//               applicationName = "my-application",
+//               deserializer = Serde.asciiString,
+//               workerIdentifier = "worker1",
+//               checkpointBatchSize = 1000L,
+//               checkpointDuration = 5.minutes
+//             )(record => q.offer(record).unit)
+//             .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
+//             .exitCode
+//      checkpointedList    <- refCheckpointedList.get
+//      xs                  <- q.takeAll
+//    } yield (checkpointedList, xs)
+//
+//  def program(shards: Shard) =
+//    for {
+//      q  <- Queue.unbounded[Record[String]]
+//      _  <- DynamicConsumer
+//             .consumeWith(
+//               streamName = "my-stream",
+//               applicationName = "my-application",
+//               deserializer = Serde.asciiString,
+//               workerIdentifier = "worker1",
+//               checkpointBatchSize = 1000L,
+//               checkpointDuration = 5.minutes
+//             )(record => q.offer(record).unit)
+//             .provideCustomLayer(DynamicConsumer.fake(shards) ++ loggingLayer)
+//             .exitCode
+//      xs <- q.takeAll
+//    } yield xs
+//
+//  override def spec =
+//    suite("DynamicConsumerFake should")(
+//      suite("when checkpointed")(
+//        testM("read from iterables when using shardsFromIterables") {
+//          for {
+//            t <- programCheckpointed(shardsFromIterables)
+//          } yield assert(t._1)(
+//            Assertion.hasSameElementsDistinct(
+//              List(
+//                record(sequenceNumber = 1, shardName = "shard0", data = "msg2"),
+//                record(sequenceNumber = 1, shardName = "shard1", data = "msg4")
+//              )
+//            )
+//          ) && assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
+//        },
+//        testM("read from streams when using shardsFromStreams") {
+//          for {
+//            t <- programCheckpointed(shardsFromStreams)
+//          } yield assert(t._1)(
+//            Assertion.hasSameElementsDistinct(
+//              List(
+//                record(sequenceNumber = 1, shardName = "shard0", data = "msg2"),
+//                record(sequenceNumber = 1, shardName = "shard1", data = "msg4")
+//              )
+//            )
+//          ) && assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
+//        }
+//      ),
+//      suite("when not checkpointed")(
+//        testM("read from iterables when using shardsFromIterables") {
+//          for {
+//            xs <- program(shardsFromIterables)
+//          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
+//        },
+//        testM("read from streams when using shardsFromStreams") {
+//          for {
+//            xs <- program(shardsFromStreams)
+//          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
+//        }
+//      )
+//    )
+//}

--- a/src/test/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFakeTest.scala
+++ b/src/test/scala/nl/vroste/zio/kinesis/client/fake/DynamicConsumerFakeTest.scala
@@ -1,129 +1,116 @@
-//package nl.vroste.zio.kinesis.client.fake
-//
-//import java.nio.ByteBuffer
-//import java.time.OffsetDateTime
-//
-//import nl.vroste.zio.kinesis.client.serde.Serde
-//import nl.vroste.zio.kinesis.client.{ DynamicConsumer, Record }
-//import software.amazon.awssdk.services.kinesis.model.EncryptionType
-//import zio.clock.Clock
-//import zio.console.Console
-//import zio.duration._
-//import zio.logging.Logging
-//import zio.stream.ZStream
-//import zio.test._
-//import zio.{ Queue, Ref, ZLayer }
-//
-//object DynamicConsumerFakeTest extends DefaultRunnableSpec {
-//  private type Shard = ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])]
-//
-//  private val now = OffsetDateTime.parse("1970-01-01T00:00:00Z")
-//
-//  private val loggingLayer: ZLayer[Any, Nothing, Logging] =
-//    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
-//
-//  private val shardsFromIterables: Shard =
-//    DynamicConsumerFake.shardsFromIterables(Serde.asciiString, List("msg1", "msg2"), List("msg3", "msg4"))
-//  private val shardsFromStreams: Shard   =
-//    DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
-//
-//  private val expectedRecords = {
-//    def recordsForShard(shardName: String, xs: String*) =
-//      xs.zipWithIndex.map {
-//        case (s, i) =>
-//          record(i.toLong, shardName, s)
-//      }
-//    recordsForShard("shard0", "msg1", "msg2") ++ recordsForShard("shard1", "msg3", "msg4")
-//  }
-//
-//  private def record(sequenceNumber: Long, shardName: String, data: String) =
-//    Record[String](
-//      sequenceNumber = s"$sequenceNumber",
-//      approximateArrivalTimestamp = now.toInstant,
-//      data = data,
-//      partitionKey = s"${shardName}_$sequenceNumber",
-//      encryptionType = EncryptionType.NONE,
-//      subSequenceNumber = None,
-//      explicitHashKey = None,
-//      aggregated = false,
-//      shardId = shardName
-//    )
-//
-//  def programCheckpointed(shards: Shard) =
-//    for {
-//      q                   <- Queue.unbounded[Record[String]]
-//      refCheckpointedList <- Ref.make[Seq[_]](Seq.empty[String])
-//      _                   <- DynamicConsumer
-//             .consumeWith(
-//               streamName = "my-stream",
-//               applicationName = "my-application",
-//               deserializer = Serde.asciiString,
-//               workerIdentifier = "worker1",
-//               checkpointBatchSize = 1000L,
-//               checkpointDuration = 5.minutes
-//             )(record => q.offer(record).unit)
-//             .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
-//             .exitCode
-//      checkpointedList    <- refCheckpointedList.get
-//      xs                  <- q.takeAll
-//    } yield (checkpointedList, xs)
-//
-//  def program(shards: Shard) =
-//    for {
-//      q  <- Queue.unbounded[Record[String]]
-//      _  <- DynamicConsumer
-//             .consumeWith(
-//               streamName = "my-stream",
-//               applicationName = "my-application",
-//               deserializer = Serde.asciiString,
-//               workerIdentifier = "worker1",
-//               checkpointBatchSize = 1000L,
-//               checkpointDuration = 5.minutes
-//             )(record => q.offer(record).unit)
-//             .provideCustomLayer(DynamicConsumer.fake(shards) ++ loggingLayer)
-//             .exitCode
-//      xs <- q.takeAll
-//    } yield xs
-//
-//  override def spec =
-//    suite("DynamicConsumerFake should")(
-//      suite("when checkpointed")(
-//        testM("read from iterables when using shardsFromIterables") {
-//          for {
-//            t <- programCheckpointed(shardsFromIterables)
-//          } yield assert(t._1)(
-//            Assertion.hasSameElementsDistinct(
-//              List(
-//                record(sequenceNumber = 1, shardName = "shard0", data = "msg2"),
-//                record(sequenceNumber = 1, shardName = "shard1", data = "msg4")
-//              )
-//            )
-//          ) && assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
-//        },
-//        testM("read from streams when using shardsFromStreams") {
-//          for {
-//            t <- programCheckpointed(shardsFromStreams)
-//          } yield assert(t._1)(
-//            Assertion.hasSameElementsDistinct(
-//              List(
-//                record(sequenceNumber = 1, shardName = "shard0", data = "msg2"),
-//                record(sequenceNumber = 1, shardName = "shard1", data = "msg4")
-//              )
-//            )
-//          ) && assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
-//        }
-//      ),
-//      suite("when not checkpointed")(
-//        testM("read from iterables when using shardsFromIterables") {
-//          for {
-//            xs <- program(shardsFromIterables)
-//          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
-//        },
-//        testM("read from streams when using shardsFromStreams") {
-//          for {
-//            xs <- program(shardsFromStreams)
-//          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
-//        }
-//      )
-//    )
-//}
+package nl.vroste.zio.kinesis.client.fake
+
+import java.time.OffsetDateTime
+
+import nl.vroste.zio.kinesis.client.serde.Serde
+import nl.vroste.zio.kinesis.client.{ DynamicConsumer, Record }
+import software.amazon.awssdk.services.kinesis.model.EncryptionType
+import zio.clock.Clock
+import zio.console.Console
+import zio.duration._
+import zio.logging.Logging
+import zio.stream.ZStream
+import zio.test._
+import zio.{ Queue, Ref, ZLayer }
+
+object DynamicConsumerFakeTest extends DefaultRunnableSpec {
+  private type Shard[T] = ZStream[Any, Nothing, (String, ZStream[Any, Throwable, T])]
+
+  private val now = OffsetDateTime.parse("1970-01-01T00:00:00Z")
+
+  private val loggingLayer: ZLayer[Any, Nothing, Logging] =
+    (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
+
+  private val shardsFromIterables: Shard[String] =
+    DynamicConsumerFake.shardsFromIterables(List("msg1", "msg2"), List("msg3", "msg4"))
+  private val shardsFromStreams: Shard[String]   =
+    DynamicConsumerFake.shardsFromStreams(ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
+
+  private val expectedRecords = {
+    def recordsForShard(shardName: String, xs: String*) =
+      xs.zipWithIndex.map {
+        case (s, i) =>
+          record(i.toLong, shardName, s)
+      }
+    recordsForShard("shard0", "msg1", "msg2") ++ recordsForShard("shard1", "msg3", "msg4")
+  }
+
+  private def record(sequenceNumber: Long, shardName: String, data: String) =
+    Record[String](
+      sequenceNumber = s"$sequenceNumber",
+      approximateArrivalTimestamp = now.toInstant,
+      data = data,
+      partitionKey = s"${shardName}_$sequenceNumber",
+      encryptionType = EncryptionType.NONE,
+      subSequenceNumber = None,
+      explicitHashKey = None,
+      aggregated = false,
+      shardId = shardName
+    )
+
+  def programCheckpointed(shards: Shard[String]) =
+    for {
+      q                   <- Queue.unbounded[Record[String]]
+      refCheckpointedList <- Ref.make[Seq[String]](Seq.empty[String])
+      _                   <- DynamicConsumer
+             .consumeWith(
+               streamName = "my-stream",
+               applicationName = "my-application",
+               deserializer = Serde.asciiString,
+               workerIdentifier = "worker1",
+               checkpointBatchSize = 1000L,
+               checkpointDuration = 5.minutes
+             )(record => q.offer(record).unit)
+             .provideCustomLayer(DynamicConsumer.fake(shards, refCheckpointedList) ++ loggingLayer)
+             .exitCode
+      checkpointedList    <- refCheckpointedList.get
+      xs                  <- q.takeAll
+    } yield (checkpointedList, xs)
+
+  def program(shards: Shard[String]) =
+    for {
+      q  <- Queue.unbounded[Record[String]]
+      _  <- DynamicConsumer
+             .consumeWith(
+               streamName = "my-stream",
+               applicationName = "my-application",
+               deserializer = Serde.asciiString,
+               workerIdentifier = "worker1",
+               checkpointBatchSize = 1000L,
+               checkpointDuration = 5.minutes
+             )(record => q.offer(record).unit)
+             .provideCustomLayer(DynamicConsumer.fake(shards) ++ loggingLayer)
+             .exitCode
+      xs <- q.takeAll
+    } yield xs
+
+  override def spec =
+    suite("DynamicConsumerFake should")(
+      suite("when checkpointed")(
+        testM("read from iterables when using shardsFromIterables") {
+          for {
+            t <- programCheckpointed(shardsFromIterables)
+          } yield assert(t._1)(Assertion.hasSameElementsDistinct(List("msg2", "msg4"))) &&
+            assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
+        },
+        testM("read from streams when using shardsFromStreams") {
+          for {
+            t <- programCheckpointed(shardsFromStreams)
+          } yield assert(t._1)(Assertion.hasSameElementsDistinct(List("msg2", "msg4"))) &&
+            assert(t._2)(Assertion.hasSameElementsDistinct(expectedRecords))
+        }
+      ),
+      suite("when not checkpointed")(
+        testM("read from iterables when using shardsFromIterables") {
+          for {
+            xs <- program(shardsFromIterables)
+          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
+        },
+        testM("read from streams when using shardsFromStreams") {
+          for {
+            xs <- program(shardsFromStreams)
+          } yield assert(xs)(Assertion.hasSameElementsDistinct(expectedRecords))
+        }
+      )
+    )
+}


### PR DESCRIPTION
Make DynamicConsumer and Checkpointer polymorphic in T to make production code more type safe and the fake API more ergonomic to use