### PR TITLE
Fix shard prediction errors for UTF8 partition keys

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
@@ -16,7 +16,7 @@ private[client] case class ShardMap(
     shardForPartitionKey(e.explicitHashKey.getOrElse(e.partitionKey))
 
   def shardForPartitionKey(key: PartitionKey): ShardId = {
-    val hashBytes = Md5Utils.computeMD5Hash(key.getBytes(StandardCharsets.US_ASCII))
+    val hashBytes = Md5Utils.computeMD5Hash(key.getBytes(StandardCharsets.UTF_8))
     val hashInt   = BigInt.apply(1, hashBytes)
 
     shards.collectFirst {


### PR DESCRIPTION
Would not be noticed for ASCII keys