### PR TITLE
Use Chunk instead of List in Producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val stdSettings: Seq[sbt.Def.SettingsDefinition] = Seq(
     "dev.zio"                %% "zio-streams"                 % zioVersion,
     "dev.zio"                %% "zio-test"                    % zioVersion % "test",
     "dev.zio"                %% "zio-test-sbt"                % zioVersion % "test",
-    "dev.zio"                %% "zio-interop-reactivestreams" % "1.3.3",
+    "dev.zio"                %% "zio-interop-reactivestreams" % "1.3.4",
     "dev.zio"                %% "zio-logging"                 % "0.5.6",
     "ch.qos.logback"          % "logback-classic"             % "1.2.3",
     "org.scala-lang.modules" %% "scala-collection-compat"     % "2.4.3",
@@ -117,7 +117,7 @@ lazy val interopFutures = (project in file("interop-futures"))
     name := "zio-kinesis-future",
     assemblyJarName in assembly := "zio-kinesis-future" + version.value + ".jar",
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio-interop-reactivestreams" % "1.3.3"
+      "dev.zio" %% "zio-interop-reactivestreams" % "1.3.4"
     )
   )
   .dependsOn(core)

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
@@ -60,7 +60,7 @@ trait Producer[T] {
    *
    * @return Task that fails if any of the records fail to be produced with a non-recoverable error
    */
-  def produceChunk(chunk: Chunk[ProducerRecord[T]]): Task[Seq[ProduceResponse]]
+  def produceChunk(chunk: Chunk[ProducerRecord[T]]): Task[Chunk[ProduceResponse]]
 
   /**
    * ZSink interface to the Producer

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/PutRecordsAggregatedBatchForShard.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/PutRecordsAggregatedBatchForShard.scala
@@ -33,7 +33,7 @@ final case class PutRecordsAggregatedBatchForShard(
   }
 
   def add(entry: ProduceRequest): PutRecordsAggregatedBatchForShard =
-    copy(entries = entries.appended(entry), payloadSize = payloadSize + payloadSizeForEntryAggregated(entry.r))
+    copy(entries = entries :+ entry, payloadSize = payloadSize + payloadSizeForEntryAggregated(entry.r))
 
   def isWithinLimits: Boolean =
     payloadSize <= maxPayloadSizePerRecord

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/PutRecordsAggregatedBatchForShard.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/PutRecordsAggregatedBatchForShard.scala
@@ -9,32 +9,31 @@ import nl.vroste.zio.kinesis.client.producer.ProducerLive.{
 }
 import nl.vroste.zio.kinesis.client.zionative.protobuf.Messages
 import nl.vroste.zio.kinesis.client.zionative.protobuf.Messages.AggregatedRecord
-import zio.{ UIO, ZIO }
+import zio.{ Chunk, UIO, ZIO }
 
 import scala.jdk.CollectionConverters._
 
 final case class PutRecordsAggregatedBatchForShard(
-  entries: List[ProduceRequest],
+  entries: Chunk[ProduceRequest],
   payloadSize: Int
 ) {
   private def builtAggregate: AggregatedRecord = {
     val builder = Messages.AggregatedRecord.newBuilder()
 
-    val entriesInOrder = entries.reverse
-    val records        = entriesInOrder.zipWithIndex.map {
+    val records = entries.zipWithIndex.map {
       case (e, index) => ProtobufAggregation.putRecordsRequestEntryToRecord(e.r, index)
     }
     builder
       .addAllRecords(records.asJava)
       .addAllExplicitHashKeyTable(
-        entriesInOrder.map(e => e.r.explicitHashKey.getOrElse("0")).asJava
+        entries.map(e => e.r.explicitHashKey.getOrElse("0")).asJava
       ) // TODO optimize: only filled ones
-      .addAllPartitionKeyTable(entriesInOrder.map(e => e.r.partitionKey).asJava)
+      .addAllPartitionKeyTable(entries.map(e => e.r.partitionKey).asJava)
       .build()
   }
 
   def add(entry: ProduceRequest): PutRecordsAggregatedBatchForShard =
-    copy(entries = entry +: entries, payloadSize = payloadSize + payloadSizeForEntryAggregated(entry.r))
+    copy(entries = entries.appended(entry), payloadSize = payloadSize + payloadSizeForEntryAggregated(entry.r))
 
   def isWithinLimits: Boolean =
     payloadSize <= maxPayloadSizePerRecord
@@ -59,7 +58,7 @@ final case class PutRecordsAggregatedBatchForShard(
 
 object PutRecordsAggregatedBatchForShard {
   val empty: PutRecordsAggregatedBatchForShard = PutRecordsAggregatedBatchForShard(
-    List.empty,
+    Chunk.empty,
     ProtobufAggregation.magicBytes.length + ProtobufAggregation.checksumSize
   )
 

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/PutRecordsBatch.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/PutRecordsBatch.scala
@@ -5,16 +5,17 @@ import nl.vroste.zio.kinesis.client.producer.ProducerLive.{
   payloadSizeForEntry,
   ProduceRequest
 }
+import zio.Chunk
 
-final case class PutRecordsBatch(entries: List[ProduceRequest], nrRecords: Int, payloadSize: Long) {
+final case class PutRecordsBatch(entries: Chunk[ProduceRequest], nrRecords: Int, payloadSize: Long) {
   def add(entry: ProduceRequest): PutRecordsBatch =
     copy(
-      entries = entry +: entries,
+      entries = entries :+ entry,
       nrRecords = nrRecords + 1,
       payloadSize = payloadSize + payloadSizeForEntry(entry.r)
     )
 
-  lazy val entriesInOrder: Seq[ProduceRequest] = entries.reverse.sortBy(e => -1 * e.attemptNumber)
+  lazy val entriesInOrder: Chunk[ProduceRequest] = entries.sortBy(e => -1 * e.attemptNumber)
 
   def isWithinLimits =
     nrRecords <= maxRecordsPerRequest &&
@@ -22,5 +23,5 @@ final case class PutRecordsBatch(entries: List[ProduceRequest], nrRecords: Int, 
 }
 
 object PutRecordsBatch {
-  val empty = PutRecordsBatch(List.empty, 0, 0)
+  val empty = PutRecordsBatch(Chunk.empty, 0, 0)
 }

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
@@ -8,7 +8,7 @@ import software.amazon.awssdk.utils.Md5Utils
 import zio.Chunk
 
 private[client] case class ShardMap(
-  shards: Iterable[(ShardId, BigInt, BigInt)],
+  shards: Chunk[(ShardId, BigInt, BigInt)],
   lastUpdated: Instant,
   invalid: Boolean = false
 ) {

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -358,7 +358,7 @@ object ProducerTest extends DefaultRunnableSpec {
     ZStream.fromIterable(input).transduce(parser).runCollect
 
   val shardMap = ShardMap(
-    Seq(
+    Chunk(
       ("001", ShardMap.minHashKey, ShardMap.maxHashKey / 2),
       ("002", ShardMap.maxHashKey / 2 + 1, ShardMap.maxHashKey)
     ),


### PR DESCRIPTION
Chunk has more efficient append performance than prepending to a List and reversing and integrates better with ZIO streams.

A rough comparison (`ProducerTest` - "efficiently") shows about 20% higher throughput and 30% less CPU usage.

```
Without Chunks:

interval=298 s, total records published=7219000, throughput=24187.33373092722 records/s, success rate=100,00 %, failed attempts=0, shard prediction errors=0, mean latency=7077 ms, 95% latency=8495 ms, min latency=379 ms, 2nd attempts=0, max attempts=1, mean latency=7077 ms, mean payload size=4355 bytes, mean record size=2473 bytes, nr PutRecords calls=23279, mean nr PutRecords calls=77.99652887134711 calls/s

With Chunks:

interval=282 s, total records published=8000000, throughput=28278.643614859015 records/s, success rate=100,00 %, failed attempts=0, shard prediction errors=0, mean latency=6432 ms, 95% latency=8059 ms, min latency=333 ms, 2nd attempts=0, max attempts=1, mean latency=6432 ms, mean payload size=3878 bytes, mean record size=2517 bytes, nr PutRecords calls=28876, mean nr PutRecords calls=102.0717641278336 calls/s
```