### PR TITLE
More producer optimizations

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/CurrentMetrics.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/CurrentMetrics.scala
@@ -63,6 +63,16 @@ private[client] final case class CurrentMetrics(
     hist
   }
 
+  def append(that: CurrentMetrics): CurrentMetrics =
+    copy(
+      nrFailed = nrFailed + that.nrFailed,
+      shardPredictionErrors = shardPredictionErrors + that.shardPredictionErrors,
+      published = published ++ that.published,
+      payloadSizes = payloadSizes ++ that.payloadSizes,
+      recordSizes = recordSizes ++ that.recordSizes,
+      latencies = latencies ++ that.latencies
+    )
+
 }
 
 private[client] object CurrentMetrics {

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
@@ -272,7 +272,7 @@ private[client] final class ProducerLive[R, R1, T](
       requests          <- ZIO.foreach(chunk) { r =>
                     for {
                       data          <- serializer.serialize(r.data)
-                      entry          = PutRecordsRequestEntry(Chunk.fromByteBuffer(data), partitionKey = r.partitionKey)
+                      entry          = PutRecordsRequestEntry(data, partitionKey = r.partitionKey)
                       predictedShard =
                         shardMap.shardForPartitionKey(entry.explicitHashKey.getOrElse(entry.partitionKey))
                     } yield (done.await, ProduceRequest(entry, onDone, now, predictedShard))
@@ -324,7 +324,7 @@ private[client] object ProducerLive {
     for {
       done          <- Promise.make[Throwable, ProduceResponse]
       data          <- serializer.serialize(r.data)
-      entry          = PutRecordsRequestEntry(Chunk.fromByteBuffer(data), partitionKey = r.partitionKey)
+      entry          = PutRecordsRequestEntry(data, partitionKey = r.partitionKey)
       predictedShard = shardMap.shardForPartitionKey(entry.explicitHashKey.getOrElse(entry.partitionKey))
     } yield (done.await, ProduceRequest(entry, done.completeWith(_).unit, now, predictedShard))
 

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/serde/Deserializer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/serde/Deserializer.scala
@@ -1,8 +1,6 @@
 package nl.vroste.zio.kinesis.client.serde
 
-import java.nio.ByteBuffer
-
-import zio.RIO
+import zio.{ Chunk, RIO }
 
 import scala.util.{ Failure, Success, Try }
 
@@ -13,7 +11,7 @@ import scala.util.{ Failure, Success, Try }
  * @tparam T Value type
  */
 trait Deserializer[-R, +T] {
-  def deserialize(data: ByteBuffer): RIO[R, T]
+  def deserialize(data: Chunk[Byte]): RIO[R, T]
 
   /**
    * Create a deserializer for a type U based on the deserializer for type T and a mapping function
@@ -47,6 +45,6 @@ object Deserializer extends Serdes {
   /**
    * Create a deserializer from a function
    */
-  def apply[R, T](deser: ByteBuffer => RIO[R, T]): Deserializer[R, T] =
-    (data: ByteBuffer) => deser(data)
+  def apply[R, T](deser: Chunk[Byte] => RIO[R, T]): Deserializer[R, T] =
+    (data: Chunk[Byte]) => deser(data)
 }

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/serde/Serde.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/serde/Serde.scala
@@ -1,8 +1,6 @@
 package nl.vroste.zio.kinesis.client.serde
 
-import java.nio.ByteBuffer
-
-import zio.RIO
+import zio.{ Chunk, RIO }
 
 import scala.util.Try
 
@@ -35,12 +33,12 @@ object Serde extends Serdes {
    * The (de)serializer functions can returned a failure ZIO with a Throwable to indicate (de)serialization failure
    */
   def apply[R, T](
-    deser: ByteBuffer => RIO[R, T]
-  )(ser: T => RIO[R, ByteBuffer]): Serde[R, T] =
+    deser: Chunk[Byte] => RIO[R, T]
+  )(ser: T => RIO[R, Chunk[Byte]]): Serde[R, T] =
     new Serde[R, T] {
-      override def serialize(value: T): RIO[R, ByteBuffer]  =
+      override def serialize(value: T): RIO[R, Chunk[Byte]]  =
         ser(value)
-      override def deserialize(data: ByteBuffer): RIO[R, T] =
+      override def deserialize(data: Chunk[Byte]): RIO[R, T] =
         deser(data)
     }
 
@@ -49,9 +47,9 @@ object Serde extends Serdes {
    */
   def apply[R, T](deser: Deserializer[R, T])(ser: Serializer[R, T]): Serde[R, T] =
     new Serde[R, T] {
-      override def serialize(value: T): RIO[R, ByteBuffer]  =
+      override def serialize(value: T): RIO[R, Chunk[Byte]]  =
         ser.serialize(value)
-      override def deserialize(data: ByteBuffer): RIO[R, T] =
+      override def deserialize(data: Chunk[Byte]): RIO[R, T] =
         deser.deserialize(data)
     }
 

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/serde/Serializer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/serde/Serializer.scala
@@ -1,8 +1,6 @@
 package nl.vroste.zio.kinesis.client.serde
 
-import java.nio.ByteBuffer
-
-import zio.RIO
+import zio.{ Chunk, RIO }
 
 /**
  * Serializer from values of some type T to a byte array
@@ -11,7 +9,7 @@ import zio.RIO
  * @tparam T
  */
 trait Serializer[-R, -T] {
-  def serialize(value: T): RIO[R, ByteBuffer]
+  def serialize(value: T): RIO[R, Chunk[Byte]]
 
   /**
    * Create a serializer for a type U based on the serializer for type T and a mapping function
@@ -31,6 +29,6 @@ object Serializer extends Serdes {
   /**
    * Create a serializer from a function
    */
-  def apply[R, T](ser: T => RIO[R, ByteBuffer]): Serializer[R, T] =
+  def apply[R, T](ser: T => RIO[R, Chunk[Byte]]): Serializer[R, T] =
     (value: T) => ser(value)
 }

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -1,6 +1,5 @@
 package nl.vroste.zio.kinesis.client.zionative
 
-import java.nio.ByteBuffer
 import java.time.Instant
 
 import io.github.vigoo.zioaws.cloudwatch.CloudWatch

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -182,7 +182,7 @@ object Consumer {
           _                 = log.debug(s"Found aggregated record with ${aggregatedRecord.getRecordsCount} sub records")
           records          <- ZIO.foreach(aggregatedRecord.getRecordsList.asScala.zipWithIndex.toSeq) {
                        case (subRecord, subSequenceNr) =>
-                         val data = subRecord.getData.asReadOnlyByteBuffer()
+                         val data = Chunk.fromByteBuffer(subRecord.getData.asReadOnlyByteBuffer())
 
                          deserializer
                            .deserialize(data)
@@ -205,7 +205,7 @@ object Consumer {
         } yield Chunk.fromIterable(records)
       else
         deserializer
-          .deserialize(ByteBuffer.wrap(r.dataValue.toArray))
+          .deserialize(r.dataValue)
           .map { data =>
             Record(
               shardId,

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -113,7 +113,7 @@ object ProducerTest extends DefaultRunnableSpec {
             totalMetrics =>
               (for {
                 _        <- putStrLn("creating stream").toManaged_
-                _        <- createStreamUnmanaged(streamName, 24).toManaged_
+                _        <- createStreamUnmanaged(streamName, 10).toManaged_
                 _        <- putStrLn("creating producer").toManaged_
                 producer <- Producer
                               .make(

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -113,7 +113,7 @@ object ProducerTest extends DefaultRunnableSpec {
             totalMetrics =>
               (for {
                 _        <- putStrLn("creating stream").toManaged_
-                _        <- createStreamUnmanaged(streamName, 10).toManaged_
+                _        <- createStreamUnmanaged(streamName, 24).toManaged_
                 _        <- putStrLn("creating producer").toManaged_
                 producer <- Producer
                               .make(

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProtobufAggregationTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProtobufAggregationTest.scala
@@ -2,7 +2,7 @@ package nl.vroste.zio.kinesis.client
 import io.github.vigoo.zioaws.kinesis.model.PutRecordsRequestEntry
 import nl.vroste.zio.kinesis.client.serde.Serde
 import nl.vroste.zio.kinesis.client.zionative.protobuf.Messages
-import zio.{ Chunk, ZIO }
+import zio.ZIO
 import zio.test.Assertion._
 import zio.test._
 
@@ -15,7 +15,7 @@ object ProtobufAggregationTest extends DefaultRunnableSpec {
 
         for {
           bytes         <- Serde.asciiString.serialize(payload)
-          entry          = PutRecordsRequestEntry(Chunk.fromByteBuffer(bytes), partitionKey = "123")
+          entry          = PutRecordsRequestEntry(bytes, partitionKey = "123")
           protobufRecord = ProtobufAggregation.putRecordsRequestEntryToRecord(entry, 0)
 
           aggregatedRecord = Messages.AggregatedRecord
@@ -27,7 +27,7 @@ object ProtobufAggregationTest extends DefaultRunnableSpec {
           encoded          = ProtobufAggregation.encodeAggregatedRecord(aggregatedRecord)
 
           decoded <- ZIO.fromTry(ProtobufAggregation.decodeAggregatedRecord(encoded))
-        } yield assert(decoded.getRecords(0).getData.asReadOnlyByteBuffer())(equalTo(bytes))
+        } yield assert(decoded.getRecords(0).getData.toByteArray)(equalTo(bytes.toArray))
 
       }
     )

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
@@ -107,7 +107,7 @@ object TestUtil {
       recordsAndBytes <- ZIO.foreach(records)(r => serializer.serialize(r.data).map((_, r.partitionKey)))
       entries          = recordsAndBytes.map {
                   case (data, partitionKey) =>
-                    PutRecordsRequestEntry(Chunk.fromByteBuffer(data), partitionKey = partitionKey)
+                    PutRecordsRequestEntry(data, partitionKey = partitionKey)
                 }
       response        <- kinesis
                     .putRecords(PutRecordsRequest(entries.toList, streamName))

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumer.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumer.scala
@@ -16,7 +16,6 @@ import zio.logging.{ Logger, Logging }
 import zio.stream.{ ZStream, ZTransducer }
 import zio._
 
-import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.UUID
 
@@ -54,7 +53,7 @@ object DynamicConsumer {
    * @return A ZLayer of the fake `DynamicConsumer` implementation
    */
   def fake(
-    shards: ZStream[Any, Throwable, (String, ZStream[Any, Throwable, ByteBuffer])],
+    shards: ZStream[Any, Throwable, (String, ZStream[Any, Throwable, Chunk[Byte]])],
     refCheckpointedList: Ref[Seq[Record[Any]]]
   ): ZLayer[Clock, Nothing, Has[Service]] =
     ZLayer.fromService[Clock.Service, DynamicConsumer.Service] { clock =>
@@ -68,7 +67,7 @@ object DynamicConsumer {
    * @return A ZLayer of the fake `DynamicConsumer` implementation
    */
   def fake(
-    shards: ZStream[Any, Throwable, (String, ZStream[Any, Throwable, ByteBuffer])]
+    shards: ZStream[Any, Throwable, (String, ZStream[Any, Throwable, Chunk[Byte]])]
   ): ZLayer[Clock, Nothing, Has[Service]] =
     ZLayer.fromServiceM[Clock.Service, Any, Nothing, DynamicConsumer.Service] { clock =>
       Ref.make[Seq[Record[Any]]](Seq.empty).map { refCheckpointedList =>

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
@@ -167,7 +167,7 @@ private[client] class DynamicConsumerLive(
       shardId: String,
       r: KinesisClientRecord
     ): ZIO[R, Throwable, DynamicConsumer.Record[T]] =
-      deserializer.deserialize(r.data()).map { data =>
+      deserializer.deserialize(Chunk.fromByteBuffer(r.data())).map { data =>
         DynamicConsumer.Record(
           shardId,
           r.sequenceNumber(),

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerFakeTest.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerFakeTest.scala
@@ -10,13 +10,12 @@ import zio.duration.durationInt
 import zio.logging.Logging
 import zio.stream.ZStream
 import zio.test._
-import zio.{ Queue, Ref, ZLayer }
+import zio.{ Chunk, Queue, Ref, ZLayer }
 
-import java.nio.ByteBuffer
 import java.time.OffsetDateTime
 
 object DynamicConsumerFakeTest extends DefaultRunnableSpec {
-  private type Shard = ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])]
+  private type Shard = ZStream[Any, Nothing, (String, ZStream[Any, Throwable, Chunk[Byte]])]
 
   private val now = OffsetDateTime.parse("1970-01-01T00:00:00Z")
 

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/examples/DynamicConsumerFakeExample.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/examples/DynamicConsumerFakeExample.scala
@@ -9,9 +9,7 @@ import zio.console.{ putStrLn, Console }
 import zio.duration.durationInt
 import zio.logging.Logging
 import zio.stream.ZStream
-import zio.{ ExitCode, Ref, URIO, ZLayer }
-
-import java.nio.ByteBuffer
+import zio.{ Chunk, ExitCode, Ref, URIO, ZLayer }
 
 /**
  * Basic usage example for `DynamicConsumerFake`
@@ -20,7 +18,7 @@ object DynamicConsumerFakeExample extends zio.App {
   val loggingLayer: ZLayer[Any, Nothing, Logging] =
     (Console.live ++ Clock.live) >>> Logging.console() >>> Logging.withRootLoggerName(getClass.getName)
 
-  private val shards: ZStream[Any, Nothing, (String, ZStream[Any, Throwable, ByteBuffer])] =
+  private val shards: ZStream[Any, Nothing, (String, ZStream[Any, Throwable, Chunk[Byte]])] =
     DynamicConsumerFake.shardsFromStreams(Serde.asciiString, ZStream("msg1", "msg2"), ZStream("msg3", "msg4"))
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =


### PR DESCRIPTION
* Only allocate 1 ref + promise per chunk instead of per element
* Increase `PutRecords` call utilization by pipelining the response processing
* Use `Chunk[Byte]` instead of `ByteBuffer` in Serdes as serialization target
* More efficient metrics combination using a map-reduce kind of method (less Ref updates necessary)
* Do not lookup the correct shard throttler for every chunk but only once per shard stream