### PR TITLE
Optimize some hot paths in Producer

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
@@ -8,7 +8,6 @@ import nl.vroste.zio.kinesis.client.producer.ProducerLive.ProduceRequest
 import nl.vroste.zio.kinesis.client.producer._
 import nl.vroste.zio.kinesis.client.serde.Serializer
 import zio._
-import zio.blocking.Blocking
 import zio.clock.{ instant, Clock }
 import zio.duration.{ Duration, _ }
 import zio.logging._
@@ -116,10 +115,10 @@ object Producer {
     serializer: Serializer[R, T],
     settings: ProducerSettings = ProducerSettings(),
     metricsCollector: ProducerMetrics => ZIO[R1, Nothing, Unit] = (_: ProducerMetrics) => ZIO.unit
-  ): ZManaged[R with R1 with Clock with Kinesis with Logging with Blocking, Throwable, Producer[T]] =
+  ): ZManaged[R with R1 with Clock with Kinesis with Logging, Throwable, Producer[T]] =
     for {
       client          <- ZManaged.service[Kinesis.Service]
-      env             <- ZIO.environment[R with Clock with Blocking].toManaged_
+      env             <- ZIO.environment[R with Clock].toManaged_
       queue           <- zio.Queue.bounded[ProduceRequest](settings.bufferSize).toManaged(_.shutdown)
       currentMetrics  <- instant.map(CurrentMetrics.empty).flatMap(Ref.make).toManaged_
       shardMap        <- getShardMap(streamName).toManaged_

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
@@ -1,6 +1,5 @@
 package nl.vroste.zio.kinesis.client
 import java.time.Instant
-
 import io.github.vigoo.zioaws.kinesis
 import io.github.vigoo.zioaws.kinesis.model.{ ListShardsRequest, ShardFilter, ShardFilterType }
 import io.github.vigoo.zioaws.kinesis.Kinesis
@@ -9,6 +8,7 @@ import nl.vroste.zio.kinesis.client.producer.ProducerLive.ProduceRequest
 import nl.vroste.zio.kinesis.client.producer._
 import nl.vroste.zio.kinesis.client.serde.Serializer
 import zio._
+import zio.blocking.Blocking
 import zio.clock.{ instant, Clock }
 import zio.duration.{ Duration, _ }
 import zio.logging._
@@ -116,10 +116,10 @@ object Producer {
     serializer: Serializer[R, T],
     settings: ProducerSettings = ProducerSettings(),
     metricsCollector: ProducerMetrics => ZIO[R1, Nothing, Unit] = (_: ProducerMetrics) => ZIO.unit
-  ): ZManaged[R with R1 with Clock with Kinesis with Logging, Throwable, Producer[T]] =
+  ): ZManaged[R with R1 with Clock with Kinesis with Logging with Blocking, Throwable, Producer[T]] =
     for {
       client          <- ZManaged.service[Kinesis.Service]
-      env             <- ZIO.environment[R with Clock].toManaged_
+      env             <- ZIO.environment[R with Clock with Blocking].toManaged_
       queue           <- zio.Queue.bounded[ProduceRequest](settings.bufferSize).toManaged(_.shutdown)
       currentMetrics  <- instant.map(CurrentMetrics.empty).flatMap(Ref.make).toManaged_
       shardMap        <- getShardMap(streamName).toManaged_

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/ProtobufAggregation.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/ProtobufAggregation.scala
@@ -5,6 +5,7 @@ import nl.vroste.zio.kinesis.client.zionative.protobuf.Messages.AggregatedRecord
 import software.amazon.awssdk.utils.Md5Utils
 import zio.Chunk
 
+import java.security.MessageDigest
 import scala.util.{ Failure, Try }
 
 object ProtobufAggregation {
@@ -30,9 +31,9 @@ object ProtobufAggregation {
   def encodedSize(ar: AggregatedRecord): Int =
     magicBytes.length + ar.getSerializedSize + checksumSize
 
-  def encodeAggregatedRecord(ar: AggregatedRecord): Chunk[Byte] = {
+  def encodeAggregatedRecord(digest: MessageDigest, ar: AggregatedRecord): Chunk[Byte] = {
     val payload  = ar.toByteArray
-    val checksum = Chunk.fromArray(Md5Utils.computeMD5Hash(payload))
+    val checksum = Chunk.fromArray(digest.digest(payload))
     Chunk.fromArray(magicBytes) ++ Chunk.fromArray(payload) ++ checksum
   }
 
@@ -46,6 +47,7 @@ object ProtobufAggregation {
       val payload  = dataChunk.slice(magicBytes.length, dataChunk.size - checksumSize)
       val checksum = dataChunk.slice(dataChunk.size - checksumSize, dataChunk.size)
 
+      // TODO do not instantiate MD5 digest every time
       val calculatedChecksum = Chunk.fromArray(Md5Utils.computeMD5Hash(payload.toArray))
 
       if (calculatedChecksum != checksum)

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/ProtobufAggregation.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/ProtobufAggregation.scala
@@ -13,6 +13,7 @@ object ProtobufAggregation {
   val magicBytes: Array[Byte] = List(0xf3, 0x89, 0x9a, 0xc2).map(_.toByte).toArray
   val checksumSize            = 16
 
+  @inline
   def putRecordsRequestEntryToRecord(
     data: Chunk[Byte],
     explicitHashKey: Option[String],

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
@@ -1,44 +1,74 @@
 package nl.vroste.zio.kinesis
 
 import io.github.vigoo.zioaws.cloudwatch.CloudWatch
-import io.github.vigoo.zioaws.core.config
 import io.github.vigoo.zioaws.core.config.AwsConfig
+import io.github.vigoo.zioaws.core.httpclient
+import io.github.vigoo.zioaws.core.httpclient.HttpClient
 import io.github.vigoo.zioaws.dynamodb.DynamoDb
 import io.github.vigoo.zioaws.kinesis.Kinesis
 import io.github.vigoo.zioaws.{ cloudwatch, dynamodb, kinesis }
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.awscore.client.builder.{ AwsAsyncClientBuilder, AwsClientBuilder }
+import software.amazon.awssdk.core.client.config.{
+  ClientAsyncConfiguration,
+  ClientOverrideConfiguration,
+  SdkAdvancedAsyncClientOption
+}
 import software.amazon.awssdk.core.retry.RetryPolicy
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder
-import zio.ZLayer
+import zio.{ Task, ZLayer }
+
+import java.util.concurrent.Executor
 
 package object client {
   def kinesisAsyncClientLayer(
     build: KinesisAsyncClientBuilder => KinesisAsyncClientBuilder = identity
   ): ZLayer[AwsConfig, Throwable, Kinesis] =
-    kinesis.customized(
-      build(_)
-        .overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(RetryPolicy.none()).build())
-    )
+    kinesis.customized(build)
 
   def cloudWatchAsyncClientLayer(
     build: CloudWatchAsyncClientBuilder => CloudWatchAsyncClientBuilder = identity
   ): ZLayer[AwsConfig, Throwable, CloudWatch] =
-    cloudwatch.customized(
-      build(_).overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(RetryPolicy.none()).build())
-    )
+    cloudwatch.customized(build)
 
   def dynamoDbAsyncClientLayer(
     build: DynamoDbAsyncClientBuilder => DynamoDbAsyncClientBuilder = identity
   ): ZLayer[AwsConfig, Throwable, DynamoDb] =
-    dynamodb.customized(
-      build(_).overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(RetryPolicy.none()).build())
-    )
+    dynamodb.customized(build)
 
   val sdkClientsLayer: ZLayer[AwsConfig, Throwable, Kinesis with CloudWatch with DynamoDb] =
     kinesisAsyncClientLayer() ++ cloudWatchAsyncClientLayer() ++ dynamoDbAsyncClientLayer()
 
+  val customConfig: ZLayer[HttpClient, Nothing, AwsConfig] =
+    ZLayer.succeed {
+      new AwsConfig.Service {
+        override def configure[Client, Builder <: AwsClientBuilder[Builder, Client]](builder: Builder): Task[Builder] =
+          Task {
+            builder.overrideConfiguration(ClientOverrideConfiguration.builder().retryPolicy(RetryPolicy.none()).build())
+          }
+
+        override def configureHttpClient[Client, Builder <: AwsAsyncClientBuilder[Builder, Client]](
+          builder: Builder,
+          serviceCaps: httpclient.ServiceHttpCapabilities
+        ): Task[Builder] =
+          Task {
+            builder
+              .asyncConfiguration(
+                ClientAsyncConfiguration
+                  .builder()
+                  .advancedOption(
+                    SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR,
+                    new Executor {
+                      override def execute(command: Runnable): Unit = command.run()
+                    }
+                  )
+                  .build()
+              )
+          }
+      }
+    }
+
   val defaultAwsLayer: ZLayer[Any, Throwable, Kinesis with CloudWatch with DynamoDb] =
-    HttpClientBuilder.make() >>> config.default >>> sdkClientsLayer
+    HttpClientBuilder.make() >>> customConfig >>> sdkClientsLayer
 }

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/package.scala
@@ -17,9 +17,7 @@ import software.amazon.awssdk.core.retry.RetryPolicy
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClientBuilder
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder
-import zio.{ Task, ZLayer }
-
-import java.util.concurrent.Executor
+import zio.{ Task, ZIO, ZLayer }
 
 package object client {
   def kinesisAsyncClientLayer(
@@ -52,16 +50,14 @@ package object client {
           builder: Builder,
           serviceCaps: httpclient.ServiceHttpCapabilities
         ): Task[Builder] =
-          Task {
+          ZIO.executor.map { executor =>
             builder
               .asyncConfiguration(
                 ClientAsyncConfiguration
                   .builder()
                   .advancedOption(
                     SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR,
-                    new Executor {
-                      override def execute(command: Runnable): Unit = command.run()
-                    }
+                    executor.asJava
                   )
                   .build()
               )

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
@@ -104,11 +104,11 @@ private[client] final class ProducerLive[R, R1, T](
   ): ZIO[Clock with Logging with Blocking, Nothing, (Option[PutRecordsResponse.ReadOnly], Chunk[ProduceRequest])] = {
     val totalPayload = batch.map(_.data.length).sum
     (for {
-//      _        <- log.info(
-//             s"PutRecords for batch of size ${batch.map(_.aggregateCount).sum} (${batch.size} aggregated). " +
-////               s"Payload sizes: ${batch.map(_.data.asByteArrayUnsafe().length).mkString(",")} " +
-//               s"(total = ${totalPayload} = ${totalPayload * 100.0 / maxPayloadSizePerRequest}%)."
-//           )
+      _        <- log.info(
+             s"PutRecords for batch of size ${batch.map(_.aggregateCount).sum} (${batch.size} aggregated). " +
+//               s"Payload sizes: ${batch.map(_.data.asByteArrayUnsafe().length).mkString(",")} " +
+               s"(total = ${totalPayload} = ${totalPayload * 100.0 / maxPayloadSizePerRequest}%)."
+           )
 
       // Avoid an allocation
       response <- zio.blocking.blocking {

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
@@ -15,6 +15,7 @@ import nl.vroste.zio.kinesis.client.serde.Serializer
 import software.amazon.awssdk.core.exception.SdkException
 import software.amazon.awssdk.services.kinesis.model.KinesisException
 import zio._
+import zio.blocking.Blocking
 import zio.clock.{ instant, Clock }
 import zio.duration._
 import zio.logging.{ log, Logging }
@@ -23,12 +24,13 @@ import zio.stream.{ ZStream, ZTransducer }
 
 import java.io.IOException
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Instant
 import scala.util.control.NonFatal
 
 private[client] final class ProducerLive[R, R1, T](
   client: Kinesis.Service,
-  env: R with Clock,
+  env: R with Clock with Blocking,
   queue: Queue[ProduceRequest],
   failedQueue: Queue[ProduceRequest],
   serializer: Serializer[R, T],
@@ -45,7 +47,7 @@ private[client] final class ProducerLive[R, R1, T](
   import ProducerLive._
   import Util.ZStreamExtensions
 
-  val runloop: ZIO[Logging with Clock, Nothing, Unit] = {
+  val runloop: ZIO[Logging with Clock with Blocking, Nothing, Unit] = {
     val retries         = ZStream.fromQueue(failedQueue, maxChunkSize = maxChunkSize)
     val chunkBufferSize = Math.ceil(settings.bufferSize * 1.0 / maxChunkSize).toInt
 
@@ -57,7 +59,9 @@ private[client] final class ProducerLive[R, R1, T](
       .groupByKey2(_.predictedShard, chunkBufferSize)
       .flatMapPar(Int.MaxValue, chunkBufferSize) {
         case (shardId @ _, requests) =>
-          requests.aggregateAsync(if (aggregate) aggregator else ZTransducer.identity)
+          ZStream.managed(ShardMap.md5.orDie).flatMap { digest =>
+            requests.aggregateAsync(if (aggregate) aggregator(digest) else ZTransducer.identity)
+          }
       })
       .groupByKey2(_.predictedShard, chunkBufferSize) // TODO can we avoid this second group by?
       .flatMapPar(Int.MaxValue, chunkBufferSize)(
@@ -97,21 +101,23 @@ private[client] final class ProducerLive[R, R1, T](
 
   private def processBatch(
     batch: Chunk[ProduceRequest]
-  ): ZIO[Clock with Logging, Nothing, (Option[PutRecordsResponse.ReadOnly], Chunk[ProduceRequest])] = {
+  ): ZIO[Clock with Logging with Blocking, Nothing, (Option[PutRecordsResponse.ReadOnly], Chunk[ProduceRequest])] = {
     val totalPayload = batch.map(_.data.length).sum
     (for {
-      _        <- log.info(
-             s"PutRecords for batch of size ${batch.map(_.aggregateCount).sum} (${batch.size} aggregated). " +
-//               s"Payload sizes: ${batch.map(_.data.asByteArrayUnsafe().length).mkString(",")} " +
-               s"(total = ${totalPayload} = ${totalPayload * 100.0 / maxPayloadSizePerRequest}%)."
-           )
+//      _        <- log.info(
+//             s"PutRecords for batch of size ${batch.map(_.aggregateCount).sum} (${batch.size} aggregated). " +
+////               s"Payload sizes: ${batch.map(_.data.asByteArrayUnsafe().length).mkString(",")} " +
+//               s"(total = ${totalPayload} = ${totalPayload * 100.0 / maxPayloadSizePerRequest}%)."
+//           )
 
       // Avoid an allocation
-      response <- client
-                    .putRecords(new PutRecordsRequest(batch.map(_.asPutRecordsRequestEntry), streamName))
-                    .mapError(_.toThrowable)
-                    .tapError(e => log.warn(s"Error producing records, will retry if recoverable: $e"))
-                    .retry(scheduleCatchRecoverable && settings.backoffRequests)
+      response <- zio.blocking.blocking {
+                    client
+                      .putRecords(new PutRecordsRequest(batch.map(_.asPutRecordsRequestEntry), streamName))
+                      .mapError(_.toThrowable)
+                      .tapError(e => log.warn(s"Error producing records, will retry if recoverable: $e"))
+                      .retry(scheduleCatchRecoverable && settings.backoffRequests)
+                  }
     } yield (Some(response), batch)).catchAll {
       case NonFatal(e) =>
         log.warn("Failed to process batch") *>
@@ -173,13 +179,16 @@ private[client] final class ProducerLive[R, R1, T](
       _ <- log.warn(responses.take(10).flatMap(_.errorCodeValue).mkString(", ")).when(newFailed.nonEmpty)
 
       // The shard map may not yet be updated unless we're experiencing high latency
-      updatedFailed <-
-        if (repredict)
-          shards.get.map(shardMap =>
-            requests.map(r => r.newAttempt.copy(predictedShard = shardMap.shardForPartitionKey(r.partitionKey)))
-          )
-        else
-          ZIO.succeed(requests.map(_.newAttempt))
+      updatedFailed <- if (repredict)
+                         ShardMap.md5.orDie.use { digest =>
+                           shards.get.map(shardMap =>
+                             requests.map(r =>
+                               r.newAttempt.copy(predictedShard = shardMap.shardForPartitionKey(digest, r.partitionKey))
+                             )
+                           )
+                         }
+                       else
+                         ZIO.succeed(requests.map(_.newAttempt))
 
       // TODO backoff for shard limit stuff
       _ <- failedQueue
@@ -283,11 +292,13 @@ private[client] final class ProducerLive[R, R1, T](
                        } yield ()
                    )
                    .unit
-      requests          <- ZIO.foreach(chunk) { r =>
-                    for {
-                      data          <- serializer.serialize(r.data)
-                      predictedShard = shardMap.shardForPartitionKey(r.partitionKey)
-                    } yield (done.await, ProduceRequest(data, r.partitionKey, onDone, now, predictedShard))
+      requests          <- ShardMap.md5.use { digest =>
+                    ZIO.foreach(chunk) { r =>
+                      for {
+                        data          <- serializer.serialize(r.data)
+                        predictedShard = shardMap.shardForPartitionKey(digest, r.partitionKey)
+                      } yield (done.await, ProduceRequest(data, r.partitionKey, onDone, now, predictedShard))
+                    }
                   }
       _                 <- queue.offerAll(requests.map(_._2))
       results           <- done.await
@@ -337,9 +348,10 @@ private[client] object ProducerLive {
     shardMap: ShardMap
   ): ZIO[R, Throwable, (ZIO[Any, Throwable, ProduceResponse], ProduceRequest)] =
     for {
-      done          <- Promise.make[Throwable, ProduceResponse]
-      data          <- serializer.serialize(r.data)
-      predictedShard = shardMap.shardForPartitionKey(r.partitionKey)
+      done <- Promise.make[Throwable, ProduceResponse]
+      data <- serializer.serialize(r.data)
+
+      predictedShard <- ShardMap.md5.use(digest => ZIO.succeed(shardMap.shardForPartitionKey(digest, r.partitionKey)))
     } yield (done.await, ProduceRequest(data, r.partitionKey, done.completeWith(_).unit, now, predictedShard))
 
   final def scheduleCatchRecoverable: Schedule[Any, Throwable, Throwable] =
@@ -401,8 +413,8 @@ private[client] object ProducerLive {
       batch.add(record)
     }.map(_.entries)
 
-  val aggregator: ZTransducer[Any, Nothing, ProduceRequest, ProduceRequest] =
+  def aggregator(digest: MessageDigest): ZTransducer[Any, Nothing, ProduceRequest, ProduceRequest] =
     foldWhile(PutRecordsAggregatedBatchForShard.empty)(_.isWithinLimits) { (batch, record: ProduceRequest) =>
       batch.add(record)
-    }.mapM(_.toProduceRequest)
+    }.mapM(_.toProduceRequest(digest))
 }

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
@@ -1,22 +1,19 @@
 package nl.vroste.zio.kinesis.client.producer
-import java.nio.charset.StandardCharsets
-import java.time.Instant
-
-import io.github.vigoo.zioaws.kinesis.model.{ PutRecordsRequestEntry, Shard }
+import io.github.vigoo.zioaws.kinesis.model.Shard
 import nl.vroste.zio.kinesis.client.producer.ProducerLive.{ PartitionKey, ShardId }
-import software.amazon.awssdk.utils.Md5Utils
-import zio.Chunk
+import zio.{ Chunk, Managed, Task, ZManaged }
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Instant
 
 private[client] final case class ShardMap(
   shards: Chunk[(ShardId, BigInt, BigInt)],
   lastUpdated: Instant,
   invalid: Boolean = false
 ) {
-  def shardForPutRecordsRequestEntry(e: PutRecordsRequestEntry): ShardId =
-    shardForPartitionKey(e.explicitHashKey.getOrElse(e.partitionKey))
-
-  def shardForPartitionKey(key: PartitionKey): ShardId = {
-    val hashBytes = Md5Utils.computeMD5Hash(key.getBytes(StandardCharsets.UTF_8))
+  def shardForPartitionKey(digest: MessageDigest, key: PartitionKey): ShardId = {
+    val hashBytes = digest.digest(key.getBytes(StandardCharsets.UTF_8))
     val hashInt   = BigInt.apply(1, hashBytes)
 
     shards.collectFirst {
@@ -28,8 +25,9 @@ private[client] final case class ShardMap(
 }
 
 private[client] object ShardMap {
-  val minHashKey: BigInt = BigInt(0)
-  val maxHashKey: BigInt = BigInt("340282366920938463463374607431768211455")
+  val minHashKey: BigInt                     = BigInt(0)
+  val maxHashKey: BigInt                     = BigInt("340282366920938463463374607431768211455")
+  val md5: Managed[Throwable, MessageDigest] = ZManaged.fromEffect(Task(MessageDigest.getInstance("MD5")))
 
   def fromShards(shards: Chunk[Shard.ReadOnly], now: Instant): ShardMap = {
     if (shards.isEmpty) throw new IllegalArgumentException("Cannot create ShardMap from empty shards list")

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
@@ -1,6 +1,7 @@
 package nl.vroste.zio.kinesis.client.producer
 import io.github.vigoo.zioaws.kinesis.model.Shard
 import nl.vroste.zio.kinesis.client.producer.ProducerLive.{ PartitionKey, ShardId }
+import nl.vroste.zio.kinesis.client.producer.ShardMap.minHashKey
 import zio.{ Chunk, Managed, Task, ZManaged }
 
 import java.nio.charset.StandardCharsets
@@ -8,7 +9,9 @@ import java.security.MessageDigest
 import java.time.Instant
 
 private[client] final case class ShardMap(
-  shards: Chunk[(ShardId, BigInt, BigInt)],
+  minHashKeys: Chunk[BigInt],
+  maxHashKeys: Chunk[BigInt],
+  shardIds: Chunk[ShardId],
   lastUpdated: Instant,
   invalid: Boolean = false
 ) {
@@ -16,9 +19,24 @@ private[client] final case class ShardMap(
     val hashBytes = digest.digest(key.getBytes(StandardCharsets.UTF_8))
     val hashInt   = BigInt.apply(1, hashBytes)
 
-    shards.collectFirst {
-      case (shardId, minHashKey, maxHashKey) if hashInt >= minHashKey && hashInt <= maxHashKey => shardId
-    }.getOrElse(throw new IllegalArgumentException(s"Could not find shard for partition key ${key}"))
+    var i                = 0
+    val len              = minHashKeys.size
+    var shardId: ShardId = null
+    while (shardId == null && i < len) {
+      val min = minHashKeys(i)
+      if (hashInt >= min) {
+        val max = maxHashKeys(i)
+        if (hashInt <= max)
+          shardId = shardIds(i)
+      }
+
+      i = i + 1
+    }
+
+    if (shardId == null)
+      throw new IllegalArgumentException(s"Could not find shard for partition key ${key}")
+
+    shardId
   }
 
   def invalidate: ShardMap = copy(invalid = true)
@@ -31,16 +49,12 @@ private[client] object ShardMap {
 
   def fromShards(shards: Chunk[Shard.ReadOnly], now: Instant): ShardMap = {
     if (shards.isEmpty) throw new IllegalArgumentException("Cannot create ShardMap from empty shards list")
+
+    val sorted = shards.sortBy(_.hashKeyRangeValue.startingHashKeyValue)
     ShardMap(
-      shards
-        .map(s =>
-          (
-            s.shardIdValue,
-            BigInt(s.hashKeyRangeValue.startingHashKeyValue),
-            BigInt(s.hashKeyRangeValue.endingHashKeyValue)
-          )
-        )
-        .sortBy(_._2),
+      sorted.map(s => BigInt(s.hashKeyRangeValue.startingHashKeyValue)).materialize,
+      sorted.map(s => BigInt(s.hashKeyRangeValue.endingHashKeyValue)).materialize,
+      sorted.map(s => s.shardIdValue),
       now
     )
   }

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ShardMap.scala
@@ -1,7 +1,6 @@
 package nl.vroste.zio.kinesis.client.producer
 import io.github.vigoo.zioaws.kinesis.model.Shard
 import nl.vroste.zio.kinesis.client.producer.ProducerLive.{ PartitionKey, ShardId }
-import nl.vroste.zio.kinesis.client.producer.ShardMap.minHashKey
 import zio.{ Chunk, Managed, Task, ZManaged }
 
 import java.nio.charset.StandardCharsets

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -1,7 +1,5 @@
 package nl.vroste.zio.kinesis.client
 
-import java.time.Instant
-import java.util.UUID
 import io.github.vigoo.zioaws.cloudwatch.CloudWatch
 import io.github.vigoo.zioaws.dynamodb.DynamoDb
 import io.github.vigoo.zioaws.kinesis
@@ -26,6 +24,8 @@ import zio.test._
 import zio.{ system, Chunk, Queue, Ref, Runtime, ZIO, ZLayer, ZManaged }
 
 import java.security.MessageDigest
+import java.time.Instant
+import java.util.UUID
 
 object ProducerTest extends DefaultRunnableSpec {
   import TestUtil._

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProtobufAggregationTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProtobufAggregationTest.scala
@@ -6,6 +6,8 @@ import zio.ZIO
 import zio.test.Assertion._
 import zio.test._
 
+import java.security.MessageDigest
+
 object ProtobufAggregationTest extends DefaultRunnableSpec {
   override def spec =
     suite("ProtobufAggregation")(
@@ -24,7 +26,7 @@ object ProtobufAggregationTest extends DefaultRunnableSpec {
                                .addPartitionKeyTable(partitionKey)
                                .addExplicitHashKeyTable(partitionKey)
                                .build()
-          encoded          = ProtobufAggregation.encodeAggregatedRecord(aggregatedRecord)
+          encoded          = ProtobufAggregation.encodeAggregatedRecord(MessageDigest.getInstance("MD5"), aggregatedRecord)
 
           decoded <- ZIO.fromTry(ProtobufAggregation.decodeAggregatedRecord(encoded))
         } yield assert(decoded.getRecords(0).getData.toByteArray)(equalTo(bytes.toArray))

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -2,9 +2,7 @@ package nl.vroste.zio.kinesis.client.zionative
 
 import java.time.Instant
 import java.{ util => ju }
-
 import scala.collection.compat._
-
 import io.github.vigoo.zioaws.kinesis
 import io.github.vigoo.zioaws.kinesis.Kinesis
 import io.github.vigoo.zioaws.kinesis.model.{ DescribeStreamRequest, ScalingType, UpdateShardCountRequest }
@@ -19,6 +17,7 @@ import nl.vroste.zio.kinesis.client.zionative.leasecoordinator.LeaseCoordination
 import nl.vroste.zio.kinesis.client.zionative.leaserepository.DynamoDbLeaseRepository
 import nl.vroste.zio.kinesis.client._
 import zio._
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.console._
 import zio.duration._
@@ -791,7 +790,7 @@ object NativeConsumerTest extends DefaultRunnableSpec {
     throttle: Option[Duration] = None,
     indexStart: Int = 1,
     aggregated: Boolean = false
-  ): ZIO[Kinesis with Clock with Logging, Throwable, Chunk[ProduceResponse]] =
+  ): ZIO[Kinesis with Clock with Logging with Blocking, Throwable, Chunk[ProduceResponse]] =
     Producer
       .make(streamName, Serde.asciiString, ProducerSettings(maxParallelRequests = 1, aggregate = aggregated))
       .use { producer =>
@@ -817,7 +816,7 @@ object NativeConsumerTest extends DefaultRunnableSpec {
     nrRecords: Int,
     chunkSize: Int = 100,
     indexStart: Int = 1
-  ): ZIO[Kinesis with Clock with Logging, Throwable, Chunk[ProduceResponse]] =
+  ): ZIO[Kinesis with Clock with Logging with Blocking, Throwable, Chunk[ProduceResponse]] =
     Producer.make(streamName, Serde.asciiString).use { producer =>
       val records =
         (indexStart until (nrRecords + indexStart)).map(i => ProducerRecord(s"key$i", s"msg$i"))


### PR DESCRIPTION
* Reduce instantations of MD5 algorithm
* Faster shard-for-partition-key-hash lookup
* Use ZIO executor instead of separate threadpool for AWS SDK `CompletableFuture` callbacks.