### PR TITLE
Unfailable periodic operation

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
@@ -129,9 +129,9 @@ object Producer {
       triggerUpdateShards <- Util.periodicAndTriggerableOperation(
                                (log.debug("Refreshing shard map") *>
                                  (getShardMap(streamName) >>= currentShardMap.set) *>
-                                 log.info("Shard map was refreshed")).tapError(e =>
-                                 log.error(s"Error refreshing shard map: ${e}").ignore
-                               ),
+                                 log.info("Shard map was refreshed"))
+                                 .tapError(e => log.error(s"Error refreshing shard map: ${e}").ignore)
+                                 .ignore,
                                settings.updateShardInterval
                              )
       throttler           <- ShardThrottler.make(allowedError = settings.allowedErrorRate)

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Util.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Util.scala
@@ -123,12 +123,12 @@ object Util {
    * After manual invocation, the next effect execution will be after interval. Any triggers during
    * effect execution are ignored.
    *
-   * @return ZIO that when executed, immediately executes the `effect`
+   * @return ZIO that when executed, immediately starts execution of `effect`
    */
-  def periodicAndTriggerableOperation[R, E, A](
-    effect: ZIO[R, E, A],
+  def periodicAndTriggerableOperation[R, A](
+    effect: ZIO[R, Nothing, A],
     period: Duration
-  ): ZManaged[R with Clock, E, UIO[Unit]] =
+  ): ZManaged[R with Clock, Nothing, UIO[Unit]] =
     for {
       queue <- Queue.dropping[Unit](1).toManaged(_.shutdown)
       _     <- ((queue.take raceFirst ZIO.sleep(period)) *> effect *> queue.takeAll).forever.forkManaged


### PR DESCRIPTION
When an error occurred while refreshing the shard map, this would cause a fiber failure on Producer termination.