### PR TITLE
DynamicConsumer: warn when getting offered records after shard queue shutdown

### DIFF
--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/Checkpointer.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/Checkpointer.scala
@@ -68,7 +68,7 @@ private[dynamicconsumer] object Checkpointer {
       override def checkEndOfShardCheckpointed: Task[Unit] =
         ZIO
           .fail(LastRecordMustBeCheckpointedException)
-          .whenM(state.get.tap(s => UIO(println(s"State at check end of shard: ${s}"))).map {
+          .whenM(state.get.map {
             case State(_, _, None, _)                                                  => false
             case State(_, None, Some(maxSequenceNumber @ _), endOfShard) if endOfShard => true
             case State(_, Some(lastCheckpointed), Some(maxSequenceNumber), endOfShard)

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumer.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumer.scala
@@ -114,8 +114,6 @@ object DynamicConsumer {
      *   well. Prefer powers of 2 for efficiency.
      * @param configureKcl
      *   Make additional KCL Scheduler configurations
-     * @param bufferOfferTimeout
-     *   Timeout before logging a warning when the KCL offers a shard's records but the buffer is full
      * @tparam R
      *   ZIO environment type required by the `deserializer`
      * @tparam T
@@ -135,8 +133,7 @@ object DynamicConsumer {
       metricsNamespace: Option[String] = None,
       workerIdentifier: String = UUID.randomUUID().toString,
       maxShardBufferSize: Int = 1024, // Prefer powers of 2
-      configureKcl: SchedulerConfig => SchedulerConfig = identity,
-      bufferOfferTimeout: Duration = 10.seconds
+      configureKcl: SchedulerConfig => SchedulerConfig = identity
     ): ZStream[
       R,
       Throwable,

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumer.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumer.scala
@@ -36,14 +36,13 @@ object DynamicConsumer {
     aggregated: Boolean
   )
 
-  val live
-    : ZLayer[Logging with Blocking with Clock with Kinesis with CloudWatch with DynamoDb, Nothing, DynamicConsumer] =
+  val live: ZLayer[Logging with Blocking with Kinesis with CloudWatch with DynamoDb, Nothing, DynamicConsumer] =
     ZLayer
       .fromServices[Logger[
         String
-      ], Blocking.Service, Clock.Service, Kinesis.Service, CloudWatch.Service, DynamoDb.Service, DynamicConsumer.Service] {
-        case (logger, blocking, clock, kinesis, cloudwatch, dynamodb) =>
-          new DynamicConsumerLive(logger, blocking, clock, kinesis.api, cloudwatch.api, dynamodb.api)
+      ], Blocking.Service, Kinesis.Service, CloudWatch.Service, DynamoDb.Service, DynamicConsumer.Service] {
+        case (logger, blocking, kinesis, cloudwatch, dynamodb) =>
+          new DynamicConsumerLive(logger, blocking, kinesis.api, cloudwatch.api, dynamodb.api)
       }
 
   /**

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
@@ -70,7 +70,6 @@ private[client] class DynamicConsumerLive(
       checkpointerInternal: CheckpointerInternal
     ) {
       def offerRecords(r: java.util.List[KinesisClientRecord]): Unit =
-        // Calls to q.offer will fail with an interruption error after the queue has been shutdown
         // We must make sure never to throw an exception here, because KCL will consider the records processed
         // See https://github.com/awslabs/amazon-kinesis-client/issues/10
         runtime.unsafeRun {
@@ -135,8 +134,6 @@ private[client] class DynamicConsumerLive(
                    q.awaitShutdown).race(q.awaitShutdown)
             _ <- logger.trace(s"stop() for ${shardId} because of ${reason} - COMPLETE")
           } yield ()
-
-          // TODO maybe we want to only do this when the main stream's completion has bubbled up..?
         }
     }
 

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
@@ -94,7 +94,7 @@ private[client] class DynamicConsumerLive(
                                  // completed but the main stream keeps running, the KCL will keep offering us records to process.
                                  ZIO.unit
                              }
-            _             <- logger.info(s"offerRecords for ${shardId} COMPLETE")
+            _             <- logger.trace(s"offerRecords for ${shardId} COMPLETE")
           } yield ()
         }
 

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
@@ -258,10 +258,11 @@ private[client] class DynamicConsumerLive(
             .mapChunksM(_.mapM(toRecord(shardId, _)))
             .provide(env)
             .ensuringFirst(
-              (checkpointer.checkEndOfShardCheckpointed *> checkpointer.checkpoint.provide(Has(blocking))).catchSome {
+              (checkpointer.checkEndOfShardCheckpointed *> checkpointer.checkpoint).catchSome {
                 case _: ShutdownException => UIO.unit
               }.orDie
             )
+            .provide(Has(blocking))
 
           (shardId, stream, checkpointer)
         }

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
@@ -76,7 +76,7 @@ private[client] class DynamicConsumerLive(
               if (queueShutdown)
                 logger.warn(
                   s"offerRecords for ${shardId} got ${records.size} records after queue shutdown. " +
-                    s"The shard stream may have ended prematurely."
+                    s"The shard stream may have ended prematurely. Records are discarded. "
                 )
               else
                 logger.debug(s"offerRecords for ${shardId} got ${records.size} records")
@@ -92,8 +92,7 @@ private[client] class DynamicConsumerLive(
                                  // This happens when the main ZStream or one of the shard's ZStreams completes, in which
                                  // case getting more records may simply be a race condition. When only the shard's stream is
                                  // completed but the main stream keeps running, the KCL will keep offering us records to process.
-                                 // At some point the queue will be full and backpressure will bubble up to the KCL.
-                                 logger.warn(s"Shard ${shardId} buffer interrupted")
+                                 ZIO.unit
                              }
             _             <- logger.info(s"offerRecords for ${shardId} COMPLETE")
           } yield ()

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerLive.scala
@@ -244,10 +244,9 @@ private[client] class DynamicConsumerLive(
                        .blocking(ZIO(scheduler.run()))
                        .fork
                        .flatMap(_.join)
-                       .onInterrupt(logger.warn("Scheduler was interrupted") *> doShutdown)
+                       .onInterrupt(doShutdown)
                        .forkManaged
         _         <- (requestShutdown *> doShutdown).forkManaged
-        _         <- ZManaged.finalizer(logger.info("Shutting down shardedStream"))
       } yield ZStream
         .fromQueue(queues.shards)
         .flattenExitOption

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/fake/DynamicConsumerFake.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/fake/DynamicConsumerFake.scala
@@ -26,8 +26,7 @@ private[client] class DynamicConsumerFake(
     metricsNamespace: Option[String],
     workerIdentifier: String,
     maxShardBufferSize: Int,
-    configureKcl: SchedulerConfig => SchedulerConfig,
-    bufferOfferTimeout: Duration
+    configureKcl: SchedulerConfig => SchedulerConfig
   ): ZStream[
     R,
     Throwable,

--- a/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/fake/DynamicConsumerFake.scala
+++ b/dynamic-consumer/src/main/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/fake/DynamicConsumerFake.scala
@@ -8,7 +8,6 @@ import software.amazon.kinesis.common.InitialPositionInStreamExtended
 import zio._
 import zio.blocking.Blocking
 import zio.clock.Clock
-import zio.duration.Duration
 import zio.stream.ZStream
 
 private[client] class DynamicConsumerFake(

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/ConsumeWithTest.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/ConsumeWithTest.scala
@@ -3,23 +3,20 @@ package nl.vroste.zio.kinesis.client.dynamicconsumer
 import io.github.vigoo.zioaws.cloudwatch.CloudWatch
 import io.github.vigoo.zioaws.dynamodb.DynamoDb
 import io.github.vigoo.zioaws.kinesis.Kinesis
+import nl.vroste.zio.kinesis.client.dynamicconsumer.DynamicConsumer.consumeWith
 import nl.vroste.zio.kinesis.client.localstack.LocalStackServices
 import nl.vroste.zio.kinesis.client.serde.Serde
 import nl.vroste.zio.kinesis.client.{ ProducerRecord, TestUtil }
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.console.{ putStrLn, Console }
-import zio.logging.Logging
-import zio.test.Assertion.equalTo
-import zio.test.TestAspect.{ sequential, timeout }
-import zio.test.{ assert, DefaultRunnableSpec }
-import zio.{ Has, Promise, Ref, ZLayer }
-import DynamicConsumer.consumeWith
 import zio.duration.durationInt
+import zio.logging.Logging
 import zio.random.Random
-import zio.test.mock.MockRandom
-
-import java.util.UUID
+import zio.test.Assertion.equalTo
+import zio.test.TestAspect.timeout
+import zio.test.{ assert, DefaultRunnableSpec }
+import zio.{ Promise, Ref, ZLayer }
 
 object ConsumeWithTest extends DefaultRunnableSpec {
   import TestUtil._

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerTest.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/DynamicConsumerTest.scala
@@ -59,10 +59,9 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                            streamName,
                            applicationName = applicationName,
                            deserializer = Serde.asciiString,
-                           configureKcl = _.withPolling,
-                           maxShardBufferSize = 32
+                           configureKcl = _.withPolling
                          )
-                         .flatMapPar(1) { case (shardId @ _, shardStream, checkpointer) =>
+                         .flatMapPar(Int.MaxValue) { case (shardId @ _, shardStream, checkpointer) =>
                            shardStream
                              .tap(r =>
                                putStrLn(s"Got record $r").orDie *> checkpointer
@@ -71,7 +70,6 @@ object DynamicConsumerTest extends DefaultRunnableSpec {
                              )
                          }
                          .runCollect
-                         .tapCause(c => logging.log.warn("Failure in consumer!", c))
 
         } yield assert(records)(hasSize(equalTo(nrShards * 2)))
       }

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/ExampleApp.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/ExampleApp.scala
@@ -261,6 +261,6 @@ object ExampleApp extends zio.App {
 
     val metricsPublisherConfig = ZLayer.succeed(CloudWatchMetricsPublisherConfig())
 
-    logging >+> awsClients >+> (dynamicConsumer ++ leaseRepo ++ metricsPublisherConfig)
+    logging >+> awsClients >+> (Blocking.live ++ Clock.live) >+> dynamicConsumer ++ leaseRepo ++ metricsPublisherConfig
   }
 }

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/examples/DynamicConsumerBasicUsageExample.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/examples/DynamicConsumerBasicUsageExample.scala
@@ -32,6 +32,6 @@ object DynamicConsumerBasicUsageExample extends zio.App {
           .via(checkpointer.checkpointBatched[Blocking with Console](nr = 1000, interval = 5.minutes))
       }
       .runDrain
-      .provideCustomLayer((loggingLayer ++ defaultAwsLayer) >>> DynamicConsumer.live)
+      .provideCustomLayer((loggingLayer ++ defaultAwsLayer ++ Blocking.any ++ Clock.any) >>> DynamicConsumer.live)
       .exitCode
 }

--- a/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/examples/DynamicConsumerConsumeWithExample.scala
+++ b/dynamic-consumer/src/test/scala/nl/vroste/zio/kinesis/client/dynamicconsumer/examples/DynamicConsumerConsumeWithExample.scala
@@ -3,6 +3,7 @@ package nl.vroste.zio.kinesis.client.dynamicconsumer.examples
 import nl.vroste.zio.kinesis.client.defaultAwsLayer
 import nl.vroste.zio.kinesis.client.dynamicconsumer.DynamicConsumer
 import nl.vroste.zio.kinesis.client.serde.Serde
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.console.{ putStrLn, Console }
 import zio.duration.durationInt
@@ -26,6 +27,6 @@ object DynamicConsumerConsumeWithExample extends zio.App {
         checkpointBatchSize = 1000L,
         checkpointDuration = 5.minutes
       )(record => putStrLn(s"Processing record $record"))
-      .provideCustomLayer((loggingLayer ++ defaultAwsLayer) >+> DynamicConsumer.live)
+      .provideCustomLayer((loggingLayer ++ defaultAwsLayer ++ Blocking.any ++ Clock.any) >+> DynamicConsumer.live)
       .exitCode
 }


### PR DESCRIPTION
Fixes #127.

Log a warning when the KCL provides records but the shard stream is prematurely ended, eg due to a `takeUntil` operator on the shard stream. This situation cannot be handled by this library; the KCL assumes that we keep processing shard records until graceful shutdown of the entire consumer. Instead we log a warning to alert the end user to make sure that each shard's stream keeps running until shutdown. No records will be skipped for that shard, they just will not be processed and the checkpoint will remain unchanged until the application (consumer) is restarted.

Also
* Provide `Blocking` dependency on construction of `DynamicConsumerLive` instead of via `shardedStream`'s environment
* Remove obsolete todo
* Remove a println