### PR TITLE
Producer speedup: Parallel shard prediction (MD5 hashing)

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
@@ -97,7 +97,8 @@ final case class ProducerSettings(
   metricsInterval: Duration = 30.seconds,
   updateShardInterval: Duration = 30.seconds,
   aggregate: Boolean = false,
-  allowedErrorRate: Double = 0.05
+  allowedErrorRate: Double = 0.05,
+  md5PoolSize: Int = 48 // TODO if not big enough, producer stalls..
 ) {
   require(allowedErrorRate > 0 && allowedErrorRate <= 1.0, "allowedErrorRate must be between 0 and 1 (inclusive)")
 }
@@ -148,7 +149,7 @@ object Producer {
                                settings.updateShardInterval
                              )
       throttler           <- ShardThrottler.make(allowedError = settings.allowedErrorRate)
-      md5Pool             <- ZPool.make(ShardMap.md5, 60)
+      md5Pool             <- ZPool.make(ShardMap.md5, settings.md5PoolSize)
 
       producer = new ProducerLive[R, R1, T](
                    client,

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Producer.scala
@@ -148,6 +148,7 @@ object Producer {
                                settings.updateShardInterval
                              )
       throttler           <- ShardThrottler.make(allowedError = settings.allowedErrorRate)
+      md5Pool             <- ZPool.make(ShardMap.md5, 60)
 
       producer = new ProducerLive[R, R1, T](
                    client,
@@ -163,7 +164,8 @@ object Producer {
                    settings.aggregate,
                    inFlightCalls,
                    triggerUpdateShards,
-                   throttler
+                   throttler,
+                   md5Pool
                  )
       _       <- producer.runloop.forkManaged                                             // Fiber cannot fail
       _       <- producer.metricsCollection.forkManaged.ensuring(producer.collectMetrics) // Fiber cannot fail

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
@@ -55,19 +55,8 @@ private[client] final class ProducerLive[R, R1, T](
     (retries merge ZStream
       .fromQueue(queue, maxChunkSize)
       .mapChunksM(chunk => log.trace(s"Dequeued chunk of size ${chunk.size}").as(Chunk.single(chunk)))
-      .mapMPar(settings.maxParallelRequests) { chunk =>
-        md5Pool.get.use { md5 =>
-          shards.get.flatMap { shardMap =>
-            chunk.mapM { r =>
-              ZIO
-                .effect(shardMap.shardForPartitionKey(md5, r.partitionKey))
-                .map(shard => r.copy(predictedShard = shard))
-            }
-          }
-        }
-      }
+      .mapMParUnordered(settings.maxParallelRequests)(addPredictedShardToRequestsChunk)
       .flattenChunks
-
       // Aggregate records per shard
       .groupByKey2(_.predictedShard, chunkBufferSize)
       .flatMapPar(Int.MaxValue, chunkBufferSize) { case (shardId @ _, requests) =>
@@ -92,6 +81,17 @@ private[client] final class ProducerLive[R, R1, T](
       .runDrain
       .orDie
   }
+
+  private def addPredictedShardToRequestsChunk(chunk: Chunk[ProduceRequest]) =
+    md5Pool.get.use { md5 =>
+      shards.get.flatMap { shardMap =>
+        chunk.mapM { r =>
+          ZIO
+            .effect(shardMap.shardForPartitionKey(md5, r.partitionKey))
+            .map(shard => r.copy(predictedShard = shard))
+        }
+      }
+    }
 
   private def throttleShardRequests(shardId: ShardId, requests: ZStream[Any, Throwable, ProduceRequest]) =
     ZStream.fromEffect(throttler.getForShard(shardId)).flatMap { throttlerForShard =>

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/producer/ProducerLive.scala
@@ -55,7 +55,7 @@ private[client] final class ProducerLive[R, R1, T](
     (retries merge ZStream
       .fromQueue(queue, maxChunkSize)
       .mapChunksM(chunk => log.trace(s"Dequeued chunk of size ${chunk.size}").as(Chunk.single(chunk)))
-      .mapMParUnordered(settings.maxParallelRequests)(addPredictedShardToRequestsChunk)
+      .mapMParUnordered(settings.shardPredictionParallelism)(addPredictedShardToRequestsChunk)
       .flattenChunks
       // Aggregate records per shard
       .groupByKey2(_.predictedShard, chunkBufferSize)

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -26,6 +26,7 @@ import zio.{ system, Chunk, Queue, Ref, Runtime, ZIO, ZLayer, ZManaged }
 import java.security.MessageDigest
 import java.time.Instant
 import java.util.UUID
+import scala.annotation.unused
 
 object ProducerTest extends DefaultRunnableSpec {
   import TestUtil._
@@ -367,13 +368,13 @@ object ProducerTest extends DefaultRunnableSpec {
     ).provideCustomLayerShared(env) @@ sequential
 
   def aggregatingBatcherForProducerRecord[R, T](
-    shardMap: ShardMap,
+    @unused shardMap: ShardMap,
     serializer: Serializer[R, T]
   ): ZTransducer[R with Logging, Throwable, ProducerRecord[T], Seq[ProduceRequest]] =
     ProducerLive
       .aggregator(MessageDigest.getInstance("MD5"))
       .contramapM((r: ProducerRecord[T]) =>
-        ProducerLive.makeProduceRequest(r, serializer, Instant.now, shardMap).map(_._2)
+        ProducerLive.makeProduceRequest(r, serializer, Instant.now).map(_._2)
       ) >>> ProducerLive.batcher
 
   def runTransducer[R, E, I, O](parser: ZTransducer[R, E, I, O], input: Iterable[I]): ZIO[R, E, Chunk[O]] =

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
@@ -126,7 +126,7 @@ object TestUtil {
       }
       .use(massProduceRecords(_, nrRecords, produceRate = Some(produceRate), maxRecordSize))
 
-  val defaultChunkSize = 2048
+  val defaultChunkSize = 1024
 
   def putRecords[R, T](
     streamName: String,

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/TestUtil.scala
@@ -126,7 +126,7 @@ object TestUtil {
       }
       .use(massProduceRecords(_, nrRecords, produceRate = Some(produceRate), maxRecordSize))
 
-  val defaultChunkSize = 1000
+  val defaultChunkSize = 2048
 
   def putRecords[R, T](
     streamName: String,


### PR DESCRIPTION
Benchmarks have shown the `MessageDigest` code for predicting a record's shard is CPU intensive. Depending on how the Producer is used, this hashing would be executed on a single fiber 
for each call to `produce` / `produceChunk`. With this change, the MD5 hashing is done in the Producer with some parallelism. 
MessageDigest instances, which cannot be used concurrently, are put in a ZPool for sharing.

Manually run test ("produce records to Kinesis successfully and efficiently") shows a 5-10% throughput improvement.