### PR TITLE
Compile java source files to Java 8 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,12 +64,13 @@ lazy val core = (project in file("core"))
   )
 
 lazy val stdSettings: Seq[sbt.Def.SettingsDefinition] = Seq(
+  Compile / compile / javacOptions ++= Seq("--release", "8"),
   Compile / compile / scalacOptions ++= {
     // This is for scala.collection.compat._
     if (scalaBinaryVersion.value == "2.13")
       Seq("-Wconf:cat=unused-imports:silent")
     else Seq.empty
-  },
+  } ++ Seq("-release", "8"),
   Test / compile / scalacOptions ++= {
     // This is for scala.collection.compat._
     if (scalaBinaryVersion.value == "2.13")


### PR DESCRIPTION
### Issue
Currently when trying to run `zio-kinesis` from an app running on JRE 11, we get the following error.

```java.lang.UnsupportedClassVersionError: nl/vroste/zio/kinesis/client/zionative/protobuf/Messages$AggregatedRecord has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0```

### Why

If no target or release compiler flags are passed, currently scala compiler defaults to java 8 when compiling. So all classes based on scala source code are valid for java8. However the `protobuf` package [contains](https://github.com/svroonland/zio-kinesis/blob/master/core/src/main/protobuf/messages.proto) a java source file (via the [sbt plugin](https://github.com/svroonland/zio-kinesis/blob/master/project/plugins.sbt#L1)), by default this gets compiled to whatever jdk version is running on the machine. This causes a mismatch in the supported versions (see console commands below)

scala source file
```console
➜  zio-kinesis git:(master) ✗ javap -verbose '/Users/work/zio/zio-kinesis/core/target/scala-2.13/classes/nl/vroste/zio/kinesis/client/Producer.class' | grep major
  major version: 52
```
 
java source file
```console
➜  zio-kinesis git:(master) ✗ javap -verbose '/Users/work/zio/zio-kinesis/core/target/scala-2.13/classes/nl/vroste/zio/kinesis/client/zionative/protobuf/Messages.class' | grep major
  major version: 61
```

### Solution

Add the java compiler flag `--release 8` to the `javacOptions`.
In addition I have also added this flag for the `scalacOptions`, although not necessary since it defaults to 8. I think it is better to be verbose, incase this default behaviour ever changes.

After adding these flags the files are now consistent.

scala source
```console
➜  zio-kinesis git:(Make_compilation_java_version_consistent) ✗ javap -verbose '/Users/work/zio/zio-kinesis/core/target/scala-2.13/classes/nl/vroste/zio/kinesis/client/Producer.class' | grep major
  major version: 52
```

java source
```console
 zio-kinesis git:(Make_compilation_java_version_consistent) ✗ javap -verbose '/Users/work/zio/zio-kinesis/core/target/scala-2.13/classes/nl/vroste/zio/kinesis/client/zionative/protobuf/Messages.class' | grep major
  major version: 52
```
