### PR TITLE
fix: Ensure checkpoints succeed for empty parent shards & Prevent child shards from being consumed while parent is active

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -322,7 +322,7 @@ object Consumer {
                                            ZStream.fail(e)
                                        case Right(EndOfShard(childShards @ _)) =>
                                          ZStream.fromZIO(
-                                           ZIO.logInfo(
+                                           ZIO.logDebug(
                                              s"Found end of shard for ${shardId}. " +
                                                s"Child shards are ${childShards.map(_.shardId).mkString(", ")}"
                                            ) *>

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -259,7 +259,7 @@ object Consumer {
         .map(_.streamDescription)
         .forkScoped // joined later
         .flatMap { streamDescriptionFib =>
-          val fetchShards = streamDescriptionFib.join.flatMap { streamDescription =>
+          val fetchInitialShards = streamDescriptionFib.join.flatMap { streamDescription =>
             if (!streamDescription.hasMoreShards)
               ZIO.succeed(streamDescription.shards.map(s => s.shardId -> s).toMap)
             else
@@ -282,7 +282,8 @@ object Consumer {
                                       workerIdentifier,
                                       emitDiagnostic,
                                       leaseCoordinationSettings,
-                                      fetchShards.provideEnvironment(env),
+                                      fetchInitialShards.provideEnvironment(env),
+                                      listShards.provideEnvironment(env),
                                       shardAssignmentStrategy,
                                       initialPosition
                                     )

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/DefaultLeaseCoordinator.scala
@@ -61,33 +61,28 @@ private class DefaultLeaseCoordinator(
 
   val now = zio.Clock.currentDateTime.map(_.toInstant())
 
-  private def initialize: ZIO[Scope, Throwable, Unit] = {
-    val getLeasesOrInitializeLeaseTable = refreshLeases.catchSome { case _: ResourceNotFoundException =>
-      table.createLeaseTableIfNotExists(applicationName) *> initialShards.flatMap(updateShards)
-    }
-
-    val periodicRefreshAndTakeLeases = repeatAndRetry(settings.refreshAndTakeInterval) {
-      (refreshLeases *> takeLeases)
-        .tapError(e => ZIO.logError(s"Refresh & take leases failed, will retry: ${e}"))
-    }
-
-    // Optimized for the 'second startup or later' situation: lease table exists and covers all shards
-    // Consumer will periodically update shards anyway
-    // Wait for shards if the lease table does not exist yet, otherwise we assume there's leases
-    // for all shards already, so just fork it. If there's new shards, the next `takeLeases` will
-    // claim leases for them.
+  private def initialize: ZIO[Scope, Throwable, Unit] =
     (for {
-      _ <- getLeasesOrInitializeLeaseTable
+      // Read existing leases or create lease table
+      _                           <- refreshLeases.catchSome { case _: ResourceNotFoundException =>
+                                       table.createLeaseTableIfNotExists(applicationName)
+                                     }
+
+      periodicRefreshAndTakeLeases = repeatAndRetry(settings.refreshAndTakeInterval) {
+                                       (refreshLeases *> takeLeases(currentShards))
+                                         .tapError(e => ZIO.logError(s"Refresh & take leases failed, will retry: ${e}"))
+                                     }
+
       // Initialization. If it fails, we will try in the loop
-      _ <- (takeLeases.retryN(1).ignore *> periodicRefreshAndTakeLeases)
-             .ensuring(ZIO.logDebug("Shutting down refresh & take lease loop"))
-             .forkScoped
-      _ <- repeatAndRetry(settings.renewInterval)(renewLeases)
-             .ensuring(ZIO.logDebug("Shutting down renew lease loop"))
-             .forkScoped
+      // initialShards will have been executed in the background so for efficiency we use it here
+      _                           <- (takeLeases(initialShards).retryN(1).ignore *> periodicRefreshAndTakeLeases)
+                                       .ensuring(ZIO.logDebug("Shutting down refresh & take lease loop"))
+                                       .forkScoped
+      _                           <- repeatAndRetry(settings.renewInterval)(renewLeases)
+                                       .ensuring(ZIO.logDebug("Shutting down renew lease loop"))
+                                       .forkScoped
     } yield ())
       .tapErrorCause(c => ZIO.logErrorCause("Error in DefaultLeaseCoordinator initialize", c))
-  }
 
   override def updateShards(shards: Map[ShardId, Shard.ReadOnly]): UIO[Unit] =
     updateStateWithDiagnosticEvents(_.updateShards(shards))
@@ -324,9 +319,10 @@ private class DefaultLeaseCoordinator(
    *
    * The effect fails with a Throwable when having failed to take one or more leases
    */
-  val takeLeases: ZIO[Any, Throwable, Unit] =
+  def takeLeases(getShards: Task[Map[ShardId, Shard.ReadOnly]]): ZIO[Any, Throwable, Unit] =
     for {
-      _      <- currentShards.flatMap(updateShards)
+      // We need to have up to date shard information to adequately decide which shards are consumable and avoid race conditions
+      _      <- getShards.flatMap(updateShards)
       leases <- state.get.map(_.currentLeases.values.toSet)
       shards <- state.get.map(_.shards.view.map { case (k, v) => ShardId.unwrap(k) -> v }.toMap)
 
@@ -336,15 +332,6 @@ private class DefaultLeaseCoordinator(
                              (lease, lastUpdated)
                          }
       consumableShards = shardsReadyToConsume(shards, leaseMap)
-
-      // before we consume a shard with a missing parent, we need to ensure we didn't just miss it due to a race
-      missingParentExists =
-        (consumableShards.values.flatMap(_.parentShardIds).toSet -- consumableShards.keySet).nonEmpty
-      updateAndRecompute  = currentShards
-                              .tap(updateShards)
-                              .map(_.map { case (k, v) => ShardId.unwrap(k) -> v }.toMap)
-                              .map(shardsReadyToConsume(_, leaseMap))
-      consumableShards   <- if (missingParentExists) updateAndRecompute else ZIO.succeed(consumableShards)
 
       desiredShards <- strategy.desiredShards(openLeases, consumableShards.keySet, workerId)
       _             <- ZIO.logInfo(s"Desired shard assignment: ${desiredShards.mkString(",")}")
@@ -432,7 +419,7 @@ private class DefaultLeaseCoordinator(
                                         updateStateWithDiagnosticEvents(_.releaseLease(updatedLease, _)) *>
                                         emitDiagnostic(DiagnosticEvent.LeaseReleased(shard)) *>
                                         emitDiagnostic(DiagnosticEvent.ShardEnded(shard)).when(shardEnded) <*
-                                        takeLeases.ignore.fork.when(shardEnded) // When it fails, the runloop will try it again sooner
+                                        takeLeases(currentShards).ignore.fork.when(shardEnded) // When it fails, the runloop will try it again sooner
                                     ).when(release)).orDie
                                 }
     } yield ()
@@ -503,11 +490,6 @@ private[zionative] object DefaultLeaseCoordinator {
   private def shardHasEnded(l: Lease) = l.checkpoint.contains(Left(SpecialCheckpoint.ShardEnd))
 
   private def parentShardsCompleted(shard: Shard.ReadOnly, leases: Map[String, Lease]): Boolean =
-    //    println(
-    //      s"Shard ${shard} has parents ${shard.parentShardIds.mkString(",")}. " +
-    //        s"Leases for these: ${shard.parentShardIds.map(id => leases.find(_.key == id).mkString(","))}"
-    //    )
-
     // Either there is no lease / the lease has already been cleaned up or it is checkpointed with SHARD_END
     shard.parentShardIds.forall(leases.get(_).exists(shardHasEnded))
 

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/LeaseCoordinationSettings.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/leasecoordinator/LeaseCoordinationSettings.scala
@@ -9,7 +9,7 @@ import zio.{ Schedule, _ }
  * Default values are compatible with KCL defaults (TODO not quite yet)
  *
  * @param refreshAndTakeInterval
- *   Interval at which leases are refreshed and possibly new leases taken
+ *   Interval at which shards and leases are refreshed and possibly new leases taken
  * @param renewInterval
  *   Interval at which leases are renewed to prevent them expiring
  * @param maxParallelLeaseAcquisitions
@@ -23,8 +23,6 @@ import zio.{ Schedule, _ }
  * @param renewRetrySchedule
  *   Schedule that controls retries when exceptions occur when renewing a lease. The lease is released (internally only)
  *   when the schedule fails.
- * @param shardRefreshInterval
- *   Interval at which the stream's shards are refreshed
  */
 final case class LeaseCoordinationSettings(
   renewInterval: Duration = 3.seconds,
@@ -32,7 +30,5 @@ final case class LeaseCoordinationSettings(
   maxParallelLeaseAcquisitions: Int = 10,
   maxParallelLeaseRenewals: Int = 10,
   releaseLeaseTimeout: Duration = 10.seconds,
-  renewRetrySchedule: Schedule[Any, Throwable, Any] =
-    Util.exponentialBackoff(3.second, 30.seconds, maxRecurs = Some(3)),
-  shardRefreshInterval: Duration = 30.seconds
+  renewRetrySchedule: Schedule[Any, Throwable, Any] = Util.exponentialBackoff(3.second, 30.seconds, maxRecurs = Some(3))
 )

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/zionative/NativeConsumerTest.scala
@@ -19,6 +19,7 @@ import zio.stream.{ ZSink, ZStream }
 import zio.test.Assertion._
 import zio.test._
 import zio.{ System, _ }
+import nl.vroste.zio.kinesis.client.zionative.LeaseRepository.Lease
 
 import scala.collection.compat._
 import java.time.Instant
@@ -802,9 +803,9 @@ object NativeConsumerTest extends ZIOSpecDefault {
         }
       },
       test("regression: correctly switch from parent to child when parent is empty") {
-        val nrShards  = 1
+        val nrShards             = 1
         val nrShardsAfterScaling = 2
-        val nrRecords = 10
+        val nrRecords            = 10
 
         withRandomStreamAndApplicationName(nrShards) { (streamName, applicationName) =>
           def consume(nr: Int) =
@@ -830,16 +831,65 @@ object NativeConsumerTest extends ZIOSpecDefault {
               .map(_._1)
 
           for {
-            _                 <- produceSampleRecords(streamName, nrRecords, aggregated = true)
-            _                 <- consume(nrRecords).runCollect
-            _                 <- scaleStream(streamName, nrShardsAfterScaling)
-            consumer          <- consume(1).runCollect.forkScoped
-            parentsCompleted   = getCheckpoints(applicationName).map(_.values.count(_ == "SHARD_END") == nrShards)
-            _                 <- parentsCompleted.delay(200.millis).repeatUntil(identity)
-            _                 <- consumer.interrupt
+            _               <- produceSampleRecords(streamName, nrRecords, aggregated = true)
+            _               <- consume(nrRecords).runCollect
+            _               <- scaleStream(streamName, nrShardsAfterScaling)
+            consumer        <- consume(1).runCollect.forkScoped
+            parentsCompleted = getCheckpoints(applicationName).map(_.values.count(_ == "SHARD_END") == nrShards)
+            _               <- parentsCompleted.delay(200.millis).repeatUntil(identity)
+            _               <- consumer.interrupt
           } yield assertCompletes
         }
       } @@ awsOnly,
+      test("regression: will not consume child shards while parent is still active") {
+        val nrRecords           = 1
+        val firstShard          = "shardId-000000000000"
+        val checkpointsToSample = 200L
+
+        withRandomStreamAndApplicationName(1) { (streamName, applicationName) =>
+          def consume(nr: Int) =
+            Consumer
+              .shardedStream(
+                streamName,
+                applicationName,
+                Serde.asciiString,
+                emitDiagnostic = e => ZIO.logDebug(e.toString)
+              )
+              .flatMapPar(Int.MaxValue, 1) { case (shard @ _, shardStream, checkpointer @ _) =>
+                shardStream.map((_, shard, checkpointer))
+              }
+              .take(nr.toLong)
+              .debug
+              .mapError[Either[Throwable, ShardLeaseLost.type]](Left(_))
+              .tap { case (r, shard, checkpointer) =>
+                checkpointer.checkpointNow[Any](r).unless(shard == firstShard)
+              }
+              .catchAll {
+                case Right(_) =>
+                  ZStream.empty
+                case Left(e)  => ZStream.fail(e)
+              }
+              .map(_._1)
+
+          def shardHasBeenConsumed(lease: Lease) =
+            lease.key == firstShard ||
+              lease.owner.nonEmpty ||
+              lease.checkpoint.exists(entry => entry == Left(SpecialCheckpoint.ShardEnd) || entry.isRight)
+
+          for {
+            _            <- produceSampleRecords(streamName, nrRecords, aggregated = true)
+            _            <- consume(nrRecords).runCollect
+            _            <- scaleStream(streamName, 2)
+            consumer     <- consume(nrRecords + 1).runCollect.forkScoped
+            activeShards <- ZStream
+                              .repeatZIOWithSchedule(getLeases(applicationName).exit, Schedule.spaced(10.millis))
+                              .collect { case Exit.Success(leases) => leases.count(shardHasBeenConsumed) }
+                              .take(checkpointsToSample)
+                              .runCollect
+            _            <- consumer.interrupt
+          } yield assert(activeShards)(forall(isLessThanEqualTo(1)))
+        }
+      } @@ awsOnly
     ).provideLayerShared(env) @@
       TestAspect.timed @@
       TestAspect.withLiveClock @@
@@ -927,12 +977,19 @@ object NativeConsumerTest extends ZIOSpecDefault {
       leases <- table.getLeases(applicationName).runCollect
     } yield assert(leases)(forall(hasField("owner", _.owner, isNone)))
 
+  def getLeases(
+    applicationName: String
+  ): ZIO[LeaseRepository, Throwable, Chunk[Lease]] =
+    for {
+      table  <- ZIO.service[LeaseRepository]
+      leases <- table.getLeases(applicationName).runCollect
+    } yield leases
+
   def getCheckpoints(
     applicationName: String
   ): ZIO[LeaseRepository, Throwable, Map[String, String]] =
     for {
-      table      <- ZIO.service[LeaseRepository]
-      leases     <- table.getLeases(applicationName).runCollect
+      leases     <- getLeases(applicationName)
       checkpoints = leases.collect {
                       case l if l.checkpoint.isDefined =>
                         l.key -> (l.checkpoint.get match {
@@ -948,14 +1005,21 @@ object NativeConsumerTest extends ZIOSpecDefault {
       .flatMap(_.deleteTable(tableName).unit)
 
   def scaleStream(streamName: String, desiredShardCount: Int) = {
-    val isActive = Kinesis.describeStream(DescribeStreamRequest(StreamName(streamName))).map(_.streamDescription.streamStatus == StreamStatus.ACTIVE)
+    val isActive = Kinesis
+      .describeStream(DescribeStreamRequest(StreamName(streamName)))
+      .map(_.streamDescription.streamStatus == StreamStatus.ACTIVE)
 
     val awaitActive = ZIO.ifZIO(isActive)(ZIO.unit, isActive.delay(200.millis).repeatUntil(identity).unit)
 
     Kinesis
-      .updateShardCount(UpdateShardCountRequest(StreamName(streamName), PositiveIntegerObject(desiredShardCount), ScalingType.UNIFORM_SCALING)) *> awaitActive
+      .updateShardCount(
+        UpdateShardCountRequest(
+          StreamName(streamName),
+          PositiveIntegerObject(desiredShardCount),
+          ScalingType.UNIFORM_SCALING
+        )
+      ) *> awaitActive
   }.mapError(_.toThrowable)
-
 
   def withRandomStreamAndApplicationName[R, A](nrShards: Int)(
     f: (String, String) => ZIO[R, Throwable, A]


### PR DESCRIPTION
resolves #845

Contains fixes for two bugs, left descriptions as comments