### PR TITLE
Allow specifying a batching timeout for the producer

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/Util.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/Util.scala
@@ -1,10 +1,18 @@
 package nl.vroste.zio.kinesis.client
 
 import zio._
-import zio.stream.ZStream
+import zio.stream.{ ZSink, ZStream }
 
 object Util {
   implicit class ZStreamExtensions[-R, +E, +O](val stream: ZStream[R, E, O]) extends AnyVal {
+
+    def aggregateAsyncWithinDuration[R1 <: R, E1 >: E, A >: O, B](
+      aggregator: ZSink[R1, E1, A, A, B],
+      timeout: Option[Duration] = None
+    ): ZStream[R1, E1, B] =
+      timeout.fold(stream.aggregateAsync(aggregator))(timeout =>
+        stream.aggregateAsyncWithin(aggregator, Schedule.spaced(timeout))
+      )
 
     def terminateOnFiberFailure[E1 >: E](fib: Fiber[E1, Any]): ZStream[R, E1, O] =
       stream

--- a/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
+++ b/core/src/test/scala/nl/vroste/zio/kinesis/client/ProducerTest.scala
@@ -66,6 +66,23 @@ object ProducerTest extends ZIOSpecDefault {
             }
         }
       },
+      test("produce requests with batching duration") {
+
+        val streamName = "zio-test-stream-producer-3"
+        val batchTime  = 1.second
+
+        withStream(streamName, 1) {
+          Producer
+            .make(streamName, Serde.asciiString, ProducerSettings(bufferSize = 128, batchDuration = Some(batchTime)))
+            .flatMap { producer =>
+              for {
+                _        <- printLine("Producing record!").orDie
+                result   <- producer.produce(ProducerRecord("bla1", "bla1value")).timed
+                (time, _) = result
+              } yield assert(time)(Assertion.isGreaterThan(batchTime))
+            }
+        }
+      },
       test("support a ramp load") {
         val streamName = "zio-test-stream-producer-ramp"
 


### PR DESCRIPTION
For applications that are not latency sensitve it makes sense to allow users to specify a batching / aggregation timeout. This will result in fewer api calls / cpu usage.

Benchmark (interesting here is records sent):

10s Batch Timeout / No Aggregation:
```
interval=405 s, total records published=8000000, throughput (records)=19708.608227358505 records/s, throughput (bytes)=282803 bytes/s, success rate=97,57 %, failed attempts=199554, shard prediction errors=0, mean latency=8546 ms, 95% latency=25775 ms, min latency=149 ms, 2nd attempts=156410, max attempts=7, mean payload size=6999 bytes, mean record size=50 bytes, nr PutRecords calls=16400, mean nr PutRecords calls=40.402646866084936 calls/s
```

No Batch Timeout / No Aggregation:
```
interval=410 s, total records published=8000000, throughput (records)=19474.76557250942 records/s, throughput (bytes)=278672 bytes/s, success rate=97,84 %, failed attempts=176810, shard prediction errors=0, mean latency=9459 ms, 95% latency=28367 ms, min latency=111 ms, 2nd attempts=145140, max attempts=8, mean payload size=2344 bytes, mean record size=50 bytes, nr PutRecords calls=48827, mean nr PutRecords calls=118.86179732611468 calls/s
```

This was with the default settings of `TestUtils.massProduceRecords`. With a lower volumne the difference will be even bigger.
