### PR TITLE
Deregister enhanced fanout consumer at shutdown

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/Consumer.scala
@@ -79,7 +79,7 @@ object FetchMode {
    *   Schedule for retrying in case of connection issues
    */
   final case class EnhancedFanOut(
-    deregisterConsumerAtShutdown: Boolean = false, // TODO
+    deregisterConsumerAtShutdown: Boolean = true,
     maxSubscriptionsPerSecond: Int = 10,
     retrySchedule: Schedule[Any, Any, (Duration, Long)] = Util.exponentialBackoff(5.second, 1.minute)
   ) extends FetchMode


### PR DESCRIPTION
This is now the default behavior, can be disabled with `FetchMode.EnhancedFanout(deregisterConsumerAtShutdown = false)`

Fixes #919