### PR TITLE
Fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         type: string
     docker:
       - image: << parameters.image >>
-      - image: localstack/localstack:latest
+      - image: localstack/localstack:3.4.0
         environment:
           LOCALSTACK_HOST: localstack
           SERVICES: 'cloudwatch,dynamodb'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,15 +17,16 @@ jobs:
         type: string
     docker:
       - image: << parameters.image >>
-      - image: localstack/localstack
+      - image: localstack/localstack:latest
         environment:
           LOCALSTACK_HOST: localstack
-          SERVICES: 'kinesis,cloudwatch,dynamodb'
+          SERVICES: 'cloudwatch,dynamodb'
           USE_SSL: "false"
           DEFAULT_REGION: 'us-east-1'
           AWS_DEFAULT_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: dummy-key
           AWS_SECRET_ACCESS_KEY: dummy-key
+          UPDATE_SHARD_COUNT_DURATION: "10000ms"
           DEBUG: "1"
     resource_class: << parameters.resource_class >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
       - run_with_localstack:
           name: test213
           image: hseeberger/scala-sbt:17.0.2_1.6.2_2.13.8
-          sbt_command: ++2.13.8! interopFutures/compile core/test interopFutures/test Compile/doc
+          sbt_command: ++2.13.13! interopFutures/compile core/test interopFutures/test Compile/doc
           requires:
             - lint
           filters:
@@ -87,7 +87,7 @@ workflows:
       - run_with_localstack:
           name: test213_dynamic_consumer
           image: hseeberger/scala-sbt:17.0.2_1.6.2_2.13.8
-          sbt_command: ++2.13.8! dynamicConsumer/test
+          sbt_command: ++2.13.13! dynamicConsumer/test
           requires:
             - lint
           filters:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:3.4.0
     healthcheck:
       test: ["CMD-SHELL", "awslocal kinesis list-streams"]
       interval: 5s


### PR DESCRIPTION
* There appears to be an issue in the latest localstack (3.5.0), where they switched to a different web server. It does work when using env var `GATEWAY_SERVER: 'hypercorn'`. Reverting to 3.4.0 for now.
* Align CI config with docker-compose
* Bump scala 2.13 version in CI