### PR TITLE
Take expired leases earlier

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategy.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/zionative/ShardAssignmentStrategy.scala
@@ -146,11 +146,11 @@ object ShardAssignmentStrategy {
     ZIO.logInfo(
       s"We have ${ourLeases.size}, we would like to have at least ${target}/${allLeases.size} leases (${activeWorkers.size} active workers, " +
         s"${zombieWorkers.size} zombie workers), we need ${minNrLeasesToTake} more with an optional ${optional}"
-    ) *> (if (minNrLeasesToTake > 0 || unownedLeases.nonEmpty)
+    ) *> (if (minNrLeasesToTake > 0 || unownedLeases.nonEmpty || expiredLeases.nonEmpty)
             for {
-              leasesWithoutOwner         <- shuffle(allLeases.filter(_.owner.isEmpty))
+              leasesWithoutOwner         <- shuffle(unownedLeases)
               leasesExpired              <- shuffle(expiredLeases)
-              leasesWithoutOwnerOrExpired = (leasesWithoutOwner ++ leasesExpired).take(maxNrLeasesToTake + optional)
+              leasesWithoutOwnerOrExpired = (leasesWithoutOwner ++ leasesExpired).take(maxNrLeasesToTake)
 
               // We can only steal from our target budget, not the optional ones
               remaining = Math.min(maxNrLeasesToTake, Math.max(0, minNrLeasesToTake - leasesWithoutOwnerOrExpired.size))


### PR DESCRIPTION
We saw an issue in production with expired leases not getting picked up by other workers immediately. This looks something like this in metrics:

<img width="1236" alt="Screenshot 2024-12-16 at 12 21 10" src="https://github.com/user-attachments/assets/f0d3e68d-7829-470b-a428-379745fead99" />

What is happening here is the following:
1. The original owner of the lease for the shard dies and cannot make a clean shutdown. This results in the lease still being assigned in the dynamodb table, but the timestamp will no longer be updated.
2. Other nodes detect the lease as being expired, but as they are already in a converged state`(minNrLeasesToTake > 0 || unownedLeases.nonEmpty)` evaluates to false, so they are not picking up the expired leases.
3. A new instance comes up for unrelated reasons (or a node shuts down)
4. One of the instances steals leases from one of the other workers (A)
5. A get's a fencing error when writing to dynmodb and calls leaseLost in the DefaultLeaseCoordinator, this in turn sets the owner of the lease to None in the internal state (until the next refreshLeases iteration)
6. `(minNrLeasesToTake > 0 || unownedLeases.nonEmpty)` evaluates to true on A as there is now an unowned lease. A takes all expired leases and starts consuming them