### PR TITLE
Remove unused imports

### DIFF
--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/HttpClientBuilder.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/HttpClientBuilder.scala
@@ -5,7 +5,6 @@ import software.amazon.awssdk.http.Protocol
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.http.nio.netty.{ Http2Configuration, NettyNioAsyncHttpClient }
 
-import zio.{ Task, ZIO, ZLayer }
 import zio._
 
 object HttpClientBuilder {

--- a/core/src/main/scala/nl/vroste/zio/kinesis/client/localstack/LocalStackServices.scala
+++ b/core/src/main/scala/nl/vroste/zio/kinesis/client/localstack/LocalStackServices.scala
@@ -17,7 +17,6 @@ import software.amazon.awssdk.core.SdkSystemSetting
 import software.amazon.awssdk.http.SdkHttpConfigurationOption
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.utils.AttributeMap
-import zio.ZLayer
 
 import java.net.URI
 import zio._


### PR DESCRIPTION
Releases started failing because of unused imports 16 days ago: https://app.circleci.com/pipelines/github/svroonland/zio-kinesis/3761/workflows/86f85b9d-8e40-41d8-8c96-0890f0aff9a5

This PR removes explicit ZIO imports in favor or the wildcard ZIO import. 